### PR TITLE
Change result of ResourceService::call_resource to reflect real world behaviour

### DIFF
--- a/src/backend/mod.rs
+++ b/src/backend/mod.rs
@@ -161,7 +161,7 @@ pub use diagnostics::{
     CheckHealthRequest, CheckHealthResponse, CollectMetricsRequest, CollectMetricsResponse,
     DiagnosticsService, HealthStatus,
 };
-pub use resource::{BoxResourceStream, CallResourceRequest, ResourceService};
+pub use resource::{BoxResourceFuture, BoxResourceStream, CallResourceRequest, ResourceService};
 pub use stream::{
     BoxRunStream, InitialData, PublishStreamRequest, PublishStreamResponse, RunStreamRequest,
     StreamPacket, StreamService, SubscribeStreamRequest, SubscribeStreamResponse,

--- a/src/backend/noop.rs
+++ b/src/backend/noop.rs
@@ -55,12 +55,7 @@ impl DiagnosticsService for NoopService {
 
 #[tonic::async_trait]
 impl ResourceService for NoopService {
-    /// The error type that can be returned by individual responses.
     type Error = Infallible;
-    /// The type of stream returned by `run_stream`.
-    ///
-    /// This will generally be impossible to name directly, so returning the
-    /// [`BoxResourceStream`] type alias will probably be more convenient.
     type Stream = BoxResourceStream<Self::Error>;
 
     /// Handle a resource request.
@@ -69,7 +64,10 @@ impl ResourceService for NoopService {
     ///
     /// A stream of responses can be returned. A simple way to return just a single response
     /// is to use `futures_util::stream::once`.
-    async fn call_resource(&self, _request: CallResourceRequest) -> Self::Stream {
+    async fn call_resource(
+        &self,
+        _request: CallResourceRequest,
+    ) -> (Result<http::Response<Vec<u8>>, Self::Error>, Self::Stream) {
         unreachable!()
     }
 }


### PR DESCRIPTION
[Grafana will only take the status and headers from the _first_
returned response in the gRPC stream][link], but that was unclear from the API.
This commit changes the signature of the `call_resource` method of the
`ResourceService` so that it must now return a single (fallible) HTTP
response, plus an (optionally empty) stream of (fallible) further
response bodies (as Vec<u8>).

[link]: https://github.com/grafana/grafana/blob/e47d7532e59cad34948652b12c5f190cdd4c6840/pkg/plugins/backendplugin/manager/manager.go#L428-L481