### PR TITLE
Improve ResourceService API to reflect Grafana behaviour; make more flexible

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,6 +16,7 @@ http = "0.2.5"
 itertools = "0.10.1"
 num-traits = "0.2.14"
 prost = "0.8.0"
+reqwest_lib = { package = "reqwest", version = "0.11.6", optional = true }
 serde = { version = "1.0.130", features = ["derive"] }
 serde_json = { version = "1.0.68", features = ["float_roundtrip", "raw_value"] }
 serde_with = "1.10.0"
@@ -32,6 +33,7 @@ tracing-subscriber = "0.2.25"
 
 [dev-dependencies]
 async-stream = "0.3.2"
+bytes = "1.1.0"
 futures = "0.3.17"
 pretty_assertions = "1.0.0"
 thiserror = "1.0.29"
@@ -40,6 +42,7 @@ tokio-stream = "0.1.7"
 tonic-health = "0.4.1"
 
 [build-dependencies]
+prost-build = "0.8.0"
 tonic-build = "0.5.2"
 
 # docs.rs-specific configuration
@@ -48,3 +51,6 @@ tonic-build = "0.5.2"
 all-features = true
 # defines the configuration attribute `docsrs`
 rustdoc-args = ["--cfg", "docsrs"]
+
+[features]
+reqwest = ["reqwest_lib"]

--- a/build.rs
+++ b/build.rs
@@ -1,3 +1,12 @@
 fn main() -> Result<(), Box<dyn std::error::Error>> {
-    Ok(tonic_build::compile_protos("vendor/proto/backend.proto")?)
+    let mut config = prost_build::Config::new();
+    config.bytes(&[
+        "CallResourceRequest",
+        "CallResourceResponse",
+    ]);
+    Ok(tonic_build::configure().compile_with_config(
+        config,
+        &["./vendor/proto/backend.proto"],
+        &["./vendor/proto"],
+    )?)
 }

--- a/src/backend/mod.rs
+++ b/src/backend/mod.rs
@@ -167,7 +167,7 @@ pub use diagnostics::{
     CheckHealthRequest, CheckHealthResponse, CollectMetricsRequest, CollectMetricsResponse,
     DiagnosticsService, HealthStatus,
 };
-pub use resource::{BoxResourceFuture, BoxResourceStream, CallResourceRequest, ResourceService};
+pub use resource::{BoxResourceFuture, BoxResourceStream, CallResourceRequest, IntoHttpResponse, ResourceService};
 pub use stream::{
     BoxRunStream, InitialData, PublishStreamRequest, PublishStreamResponse, RunStreamRequest,
     StreamPacket, StreamService, SubscribeStreamRequest, SubscribeStreamResponse,

--- a/src/backend/noop.rs
+++ b/src/backend/noop.rs
@@ -56,6 +56,7 @@ impl DiagnosticsService for NoopService {
 #[tonic::async_trait]
 impl ResourceService for NoopService {
     type Error = Infallible;
+    type InitialResponse = Vec<u8>;
     type Stream = BoxResourceStream<Self::Error>;
 
     /// Handle a resource request.
@@ -67,7 +68,7 @@ impl ResourceService for NoopService {
     async fn call_resource(
         &self,
         _request: CallResourceRequest,
-    ) -> (Result<http::Response<Vec<u8>>, Self::Error>, Self::Stream) {
+    ) -> (Result<Self::InitialResponse, Self::Error>, Self::Stream) {
         unreachable!()
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -26,6 +26,10 @@ the [crate examples] or [sample app repo] to get started with writing a backend 
 */
 #![cfg_attr(docsrs, feature(doc_notable_trait))]
 #![deny(missing_docs)]
+
+#[cfg(feature = "reqwest")]
+extern crate reqwest_lib as reqwest;
+
 #[allow(missing_docs, clippy::all, clippy::nursery, clippy::pedantic)]
 pub mod pluginv2 {
     //! The low-level structs generated from protocol definitions.


### PR DESCRIPTION
This commit:

- changes the `ResourceService` API to reflect the way Grafana treats
  streams of data
- adds a new `IntoHttpResponse` trait and some basic implementations
- allows the `ResourceService::call_resource` function to return
  anything that can be converted into a `http::Response`
- adds a blanket impl of `ResourceService` for functions with the
  correct signature.