### PR TITLE
Improve docs and examples for streams

### DIFF
--- a/examples/main.rs
+++ b/examples/main.rs
@@ -109,7 +109,7 @@ impl backend::StreamService for MyPluginService {
         info!("Running stream");
         let mut x = 0u32;
         let n = 3;
-        let mut frame = data::Frame::new("foo");
+        let mut frame = data::Frame::new("foo").with_field((x..x + n).into_field("x"));
         Box::pin(
             async_stream::try_stream! {
                 loop {


### PR DESCRIPTION
Fix the examples and doctests for streams, and add some information about when the various methods are called by Grafana.