### PR TITLE
Improve ergonomics for resource service implementations

### DIFF
--- a/src/backend/mod.rs
+++ b/src/backend/mod.rs
@@ -150,7 +150,8 @@ pub use diagnostics::{
     DiagnosticsService, HealthStatus, Payload as MetricsPayload,
 };
 pub use resource::{
-    BoxResourceFuture, BoxResourceStream, CallResourceRequest, IntoHttpResponse, ResourceService,
+    BoxResourceFuture, BoxResourceStream, CallResourceRequest, ErrIntoHttpResponse,
+    IntoHttpResponse, ResourceService,
 };
 pub use stream::{
     BoxRunStream, InitialData, PublishStreamRequest, PublishStreamResponse, RunStreamRequest,

--- a/src/backend/noop.rs
+++ b/src/backend/noop.rs
@@ -68,7 +68,7 @@ impl ResourceService for NoopService {
     async fn call_resource(
         &self,
         _request: CallResourceRequest,
-    ) -> (Result<Self::InitialResponse, Self::Error>, Self::Stream) {
+    ) -> Result<(Self::InitialResponse, Self::Stream), Self::Error> {
         unreachable!()
     }
 }


### PR DESCRIPTION
The overall return type for `call_resource` is now a Result,
which means the ? operator can be used throughout. The associated error
type must also be able to be converted into a HTTP response using the
new `ErrIntoHttpResponse` trait.