### PR TITLE
Update backend.proto; make various request structs non_exhaustive; add 'data' fields

### DIFF
--- a/build.rs
+++ b/build.rs
@@ -3,6 +3,8 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
     config.bytes(&[
         ".pluginv2.CallResourceRequest",
         ".pluginv2.CallResourceResponse",
+        ".pluginv2.RunStreamRequest",
+        ".pluginv2.SubscribeStreamRequest",
     ]);
     Ok(tonic_build::configure().compile_with_config(
         config,

--- a/examples/main.rs
+++ b/examples/main.rs
@@ -101,10 +101,7 @@ impl backend::StreamService for MyPluginService {
             backend::SubscribeStreamStatus::NotFound
         };
         info!(path = %request.path, "Subscribing to stream");
-        Ok(backend::SubscribeStreamResponse {
-            status,
-            initial_data: None,
-        })
+        Ok(backend::SubscribeStreamResponse::new(status, None))
     }
 
     type Error = StreamError;

--- a/src/backend/data.rs
+++ b/src/backend/data.rs
@@ -13,6 +13,7 @@ use crate::{
 /// Details of the request source can be found in `plugin_context`,
 /// while the actual plugins themselves are in `queries`.
 #[derive(Debug)]
+#[non_exhaustive]
 pub struct QueryDataRequest {
     /// Details of the plugin instance from which the request originated.
     ///
@@ -52,6 +53,7 @@ impl TryFrom<pluginv2::QueryDataRequest> for QueryDataRequest {
 ///
 /// The `json` field contains any fields set by the plugin's UI.
 #[derive(Debug)]
+#[non_exhaustive]
 pub struct DataQuery {
     /// The unique identifier of the query, set by the frontend call.
     ///

--- a/src/backend/resource.rs
+++ b/src/backend/resource.rs
@@ -16,6 +16,7 @@ use crate::{
 
 /// A request for a resource call.
 #[derive(Debug)]
+#[non_exhaustive]
 pub struct CallResourceRequest<T = Bytes> {
     /// Details of the plugin instance from which the request originated.
     pub plugin_context: Option<PluginContext>,

--- a/vendor/proto/backend.proto
+++ b/vendor/proto/backend.proto
@@ -179,7 +179,7 @@ service Stream {
   // SubscribeStream called when a user tries to subscribe to a plugin/datasource
   // managed channel path – thus plugin can check subscribe permissions and communicate
   // options with Grafana Core. When the first subscriber joins a channel, RunStream
-  // will be called. 
+  // will be called.
   rpc SubscribeStream(SubscribeStreamRequest) returns (SubscribeStreamResponse);
 
   // RunStream will be initiated by Grafana to consume a stream. RunStream will be
@@ -200,6 +200,9 @@ message SubscribeStreamRequest {
 
   // path part of channel.
   string path = 2;
+  // optional raw data. May be used as an extra payload supplied upon subscription.
+  // For example, can contain JSON query object.
+  bytes data = 3;
 }
 
 message SubscribeStreamResponse {
@@ -249,6 +252,9 @@ message RunStreamRequest {
 
   // path part of a channel.
   string path = 2;
+  // optional raw data. May be used as an extra payload supplied upon subscription.
+  // For example, can contain JSON query object.
+  bytes data = 3;
 }
 
 message StreamPacket {


### PR DESCRIPTION
The underlying protocol is not under our control (as evidenced here),
and we may want to add fields to the various request types as time goes
on. Making these structs non_exhaustive means we can do so without a
major version bump.

This PR updates the version of backend.proto in the process, and adds the new `data` fields of `RunStreamRequest` and `SubscribeStreamRequest` added in https://github.com/grafana/grafana-plugin-sdk-go/pull/434.