### PR TITLE
Export arrow2

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -34,6 +34,8 @@ The following feature flags enable additional functionality for this crate:
 #![cfg_attr(docsrs, feature(doc_notable_trait))]
 #![deny(missing_docs)]
 
+pub use arrow2;
+
 #[cfg(feature = "reqwest")]
 extern crate reqwest_lib as reqwest;
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -34,6 +34,11 @@ The following feature flags enable additional functionality for this crate:
 #![cfg_attr(docsrs, feature(doc_notable_trait))]
 #![deny(missing_docs)]
 
+/// Re-export of the arrow2 crate depended on by this crate.
+///
+/// We recommend that you use this re-export rather than depending on arrow2
+/// directly to ensure compatibility; otherwise, rustc/cargo may emit mysterious
+/// error messages.
 pub use arrow2;
 
 #[cfg(feature = "reqwest")]


### PR DESCRIPTION
## Why

I attempted to use `downcast_ref` with the appropriate `arrow2` types, but since my crate's arrow2 dependency didn't match the plugin SDK's arrow2 dependency, `downcast_ref` was failing.

```rs
frame.values().as_any().downcast_ref::<PrimitiveArray<i64>>();
```

## What

It seems like the only solution was to export the `arrow2` so that other crates can access frame values. Not sure if there's a better approach here.