### PR TITLE
Change query_data to return a stream instead of an iterator

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,6 +27,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   - `Role` (is also now `Copy`)
   - `TimeRange`
   - `User`
+- Change the `Iter` associated type of `backend::DataService` to `Stream`, and update
+  the return type of `query_data` accordingly. This allows each inner query to be handled
+  asynchronously and concurrently in a simple way.
 
 ## [0.1.0] - 2021-12-08
 

--- a/src/backend/noop.rs
+++ b/src/backend/noop.rs
@@ -29,8 +29,8 @@ impl DataQueryError for Infallible {
 #[tonic::async_trait]
 impl DataService for NoopService {
     type QueryError = Infallible;
-    type Iter = BoxDataResponseIter<Self::QueryError>;
-    async fn query_data(&self, _request: QueryDataRequest) -> Self::Iter {
+    type Stream = BoxDataResponseStream<Self::QueryError>;
+    async fn query_data(&self, _request: QueryDataRequest) -> Self::Stream {
         unreachable!()
     }
 }


### PR DESCRIPTION
This allows the inner queries to be handled concurrently without
needing the user to deal with spawning and joining tasks within the
query_data method.
