### PR TITLE
Mark all pub types #[non_exhaustive]

### DIFF
--- a/src/backend/mod.rs
+++ b/src/backend/mod.rs
@@ -658,6 +658,7 @@ pub(self) fn read_json(jdoc: &[u8]) -> ConvertFromResult<Value> {
 
 /// The time range for a query.
 #[derive(Clone, Debug)]
+#[non_exhaustive]
 pub struct TimeRange {
     /// The start time of the query.
     pub from: DateTime<Utc>,
@@ -676,6 +677,7 @@ impl From<pluginv2::TimeRange> for TimeRange {
 
 /// A role within Grafana.
 #[derive(Clone, Copy, Debug)]
+#[non_exhaustive]
 pub enum Role {
     /// Admin users can perform any administrative action, such as adding and removing users and datasources.
     Admin,
@@ -699,6 +701,7 @@ impl FromStr for Role {
 
 /// A Grafana user.
 #[derive(Clone, Debug)]
+#[non_exhaustive]
 pub struct User {
     /// The user's login.
     pub login: String,
@@ -727,6 +730,7 @@ impl TryFrom<pluginv2::User> for User {
 /// An app instance is an app plugin of a certain type that has been configured
 /// and enabled in a Grafana organisation.
 #[derive(Clone)]
+#[non_exhaustive]
 pub struct AppInstanceSettings {
     /// Includes the non-secret settings of the app instance (excluding datasource config).
     pub json_data: Value,
@@ -768,6 +772,7 @@ impl TryFrom<pluginv2::AppInstanceSettings> for AppInstanceSettings {
 /// the Prometheus datasource plugin, and there may be many configured Prometheus
 /// datasource instances configured in a Grafana organisation.
 #[derive(Clone)]
+#[non_exhaustive]
 pub struct DataSourceInstanceSettings {
     /// The Grafana assigned numeric identifier of the the datasource instance.
     pub id: i64,
@@ -850,6 +855,7 @@ impl TryFrom<pluginv2::DataSourceInstanceSettings> for DataSourceInstanceSetting
 
 /// Holds contextual information about a plugin request: Grafana org, user, and plugin instance settings.
 #[derive(Clone, Debug)]
+#[non_exhaustive]
 pub struct PluginContext {
     /// The organisation ID from which the request originated.
     pub org_id: i64,

--- a/src/data/error.rs
+++ b/src/data/error.rs
@@ -7,6 +7,7 @@ use super::frame::to_arrow;
 
 /// Errors that can occur when interacting with the Grafana plugin SDK.
 #[derive(Debug, Error)]
+#[non_exhaustive]
 pub enum Error {
     /// An error has occurred when serializing to Arrow IPC format.
     #[error("Arrow serialization error: {0}")]

--- a/src/data/field.rs
+++ b/src/data/field.rs
@@ -117,12 +117,11 @@ impl Field {
     /// ```rust
     /// use grafana_plugin_sdk::{data::FieldConfig, prelude::*};
     ///
+    /// let mut config = FieldConfig::default();
+    /// config.display_name_from_ds = Some("X".to_string());
     /// let field = ["a", "b", "c"]
     ///     .into_field("x")
-    ///     .with_config(FieldConfig {
-    ///         display_name_from_ds: Some("X".to_string()),
-    ///         ..Default::default()
-    ///     });
+    ///     .with_config(config);
     /// assert_eq!(&field.config.unwrap().display_name_from_ds.unwrap(), "X");
     /// ```
     #[must_use]
@@ -517,6 +516,7 @@ impl TypeInfoType {
 /// The 'simple' type of this data.
 #[derive(Debug, Deserialize, Serialize)]
 #[serde(rename_all = "lowercase")]
+#[non_exhaustive]
 pub enum SimpleType {
     /// A number.
     Number,
@@ -531,12 +531,17 @@ pub enum SimpleType {
 /// The display properties for a [`Field`].
 ///
 /// These are used by the Grafana frontend to modify how the field is displayed.
+///
+/// Note that this struct, like most structs in this crate, is marked `#[non_exhaustive]` and
+/// therefore cannot be constructed using a struct expression. Instead, create a default
+/// value using `FieldConfig::default()` and modify any fields necessary.
 // This struct needs to match the frontend component defined in:
 // https://github.com/grafana/grafana/blob/master/packages/grafana-data/src/types/dataFrame.ts#L23
 // All properties are optional should be omitted from JSON when empty or not set.
 #[skip_serializing_none]
 #[derive(Clone, Debug, Default, PartialEq, Serialize, Deserialize)]
 #[serde(rename_all = "camelCase")]
+#[non_exhaustive]
 pub struct FieldConfig {
     /// Overrides Grafana default naming.
     ///
@@ -613,6 +618,7 @@ pub struct FieldConfig {
 /// Special values that can be mapped to new text and colour values.
 #[derive(Clone, Copy, Debug, PartialEq, Serialize, Deserialize)]
 #[serde(untagged, rename_all = "camelCase")]
+#[non_exhaustive]
 pub enum SpecialValueMatch {
     /// Match `true`.
     True,
@@ -633,6 +639,7 @@ pub enum SpecialValueMatch {
 #[skip_serializing_none]
 #[derive(Clone, Debug, PartialEq, Serialize, Deserialize)]
 #[serde(tag = "type", content = "options", rename_all = "camelCase")]
+#[non_exhaustive]
 pub enum ValueMapping {
     /// Map strings to new strings directly.
     ValueMapper(HashMap<String, ValueMappingResult>),
@@ -657,8 +664,9 @@ pub enum ValueMapping {
 
 /// A new value to be displayed when a [`ValueMapping`] matches an input value.
 #[skip_serializing_none]
-#[derive(Clone, Debug, PartialEq, Serialize, Deserialize)]
+#[derive(Clone, Debug, Default, PartialEq, Serialize, Deserialize)]
 #[serde(rename_all = "camelCase")]
+#[non_exhaustive]
 pub struct ValueMappingResult {
     /// The text to display.
     #[serde(default)]
@@ -672,8 +680,9 @@ pub struct ValueMappingResult {
 }
 
 /// Configuration for thresholds for a field.
-#[derive(Clone, Debug, PartialEq, Serialize, Deserialize)]
+#[derive(Clone, Debug, Default, PartialEq, Serialize, Deserialize)]
 #[serde(rename_all = "camelCase")]
+#[non_exhaustive]
 pub struct ThresholdsConfig {
     /// How thresholds should be evaluated.
     pub mode: ThresholdsMode,
@@ -683,8 +692,9 @@ pub struct ThresholdsConfig {
 
 /// A single step on the threshold list.
 #[skip_serializing_none]
-#[derive(Clone, Debug, PartialEq, Serialize, Deserialize)]
+#[derive(Clone, Debug, Default, PartialEq, Serialize, Deserialize)]
 #[serde(rename_all = "camelCase")]
+#[non_exhaustive]
 pub struct Threshold {
     /// The upper bound of this threshold.
     pub value: Option<ConfFloat64>,
@@ -697,17 +707,27 @@ pub struct Threshold {
 /// How thresholds should be evaluated.
 #[derive(Clone, Debug, PartialEq, Serialize, Deserialize)]
 #[serde(rename_all = "camelCase")]
+#[non_exhaustive]
 pub enum ThresholdsMode {
     /// Pick thresholds based on the absolute value.
+    ///
+    /// This is the default value.
     Absolute,
     /// Thresholds should be treated as relative to the min/max.
     Percentage,
 }
 
+impl Default for ThresholdsMode {
+    fn default() -> Self {
+        Self::Absolute
+    }
+}
+
 /// Links to use when clicking on a result.
 #[skip_serializing_none]
-#[derive(Clone, Debug, PartialEq, Serialize, Deserialize)]
+#[derive(Clone, Debug, Default, PartialEq, Serialize, Deserialize)]
 #[serde(rename_all = "camelCase")]
+#[non_exhaustive]
 pub struct DataLink {
     /// The title text to display.
     pub title: Option<String>,

--- a/src/data/frame/to_arrow.rs
+++ b/src/data/frame/to_arrow.rs
@@ -8,6 +8,7 @@ use crate::data::{field::Field, frame::CheckedFrame};
 
 /// Errors occurring when serializing a [`Frame`] to the Arrow IPC format.
 #[derive(Debug, Error)]
+#[non_exhaustive]
 pub enum Error {
     /// An error occurred converting the frame's metadata to JSON.
     #[error("Error serializing metadata")]

--- a/src/data/mod.rs
+++ b/src/data/mod.rs
@@ -1,4 +1,35 @@
 //! Data types used throughout the SDK.
+//!
+//! Note that many of the types in this module are marked as `#[non_exhaustive]` and cannot
+//! be constructed using struct expressions. This is because Grafana may choose to add
+//! additional fields or variants at any time. Instead, use the constructor (if available) or
+//! create a mutable default value using `Default::default()` and modify any fields.
+//!
+//! For example:
+//!
+//! ```
+//! use grafana_plugin_sdk::{
+//!     data::{Field, FieldConfig, Frame, Metadata, Notice, Severity},
+//!     prelude::*,
+//! };
+//!
+//! let mut field_config = FieldConfig::default();
+//! field_config.display_name_from_ds = Some("X".to_string());
+//! let field = ["a", "b", "c"]
+//!     .into_field("x")
+//!     .with_config(field_config);
+//!
+//! let mut notice = Notice::new("warning! this is important".to_string());
+//! notice.severity = Some(Severity::Warning);
+//! let mut metadata = Metadata::default();
+//! metadata.path = Some("my path".to_string());
+//! metadata.notices = Some(vec![notice]);
+//!
+//! let frame = Frame::new("my frame")
+//!     .with_field(field)
+//!     .with_metadata(metadata);
+//! # assert_eq!(frame.fields()[0].config.as_ref().unwrap().display_name_from_ds, Some("X".to_string()));
+//! ```
 use serde::{ser::Serializer, Deserialize, Serialize};
 
 mod error;

--- a/src/live/channel.rs
+++ b/src/live/channel.rs
@@ -14,6 +14,7 @@ pub const MAX_CHANNEL_LENGTH: usize = 160;
 
 /// The error returned when parsing a channel.
 #[derive(Debug, Error)]
+#[non_exhaustive]
 pub enum Error {
     /// The channel was empty.
     #[error("Channel must not be empty")]
@@ -124,7 +125,7 @@ impl Namespace {
     ///
     /// # Errors
     ///
-    /// Returns an [`struct@Error`] if the provided string contains invalid characters.
+    /// Returns an [`enum@Error`] if the provided string contains invalid characters.
     pub fn new(s: String) -> Result<Self> {
         if s.chars().any(|c| !Self::is_valid_char(c)) {
             let invalid = s
@@ -175,7 +176,7 @@ impl Path {
     ///
     /// # Errors
     ///
-    /// Returns an [`struct@Error`] if the provided string contains invalid characters.
+    /// Returns an [`enum@Error`] if the provided string contains invalid characters.
     pub fn new(s: String) -> Result<Self> {
         if s.chars().any(|c| !Self::is_valid_char(c)) {
             let invalid = s


### PR DESCRIPTION
More fields or variants could be added to Grafana at any time, and we'd
need to release a new minor version without these structs/enums
being marked `#[non_exhaustive]`. This does unfortunately make the
API a bit less convenient to use unless we provide `with_x` methods
all over the place, which we could always do later.

This follows on from #34 but applies to the `data` module instead of the `backend` one.