### PR TITLE
Release version 0.2.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.2.0] - 2022-03-15
+
 ### Added
 
 - Bump arrow2 dependency to 0.10.0, and re-export it as `grafana_plugin_sdk::arrow2`
@@ -51,5 +53,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Initial release of the SDK
 
-[unreleased]: https://github.com/sd2k/grafana-plugin-sdk-rust/compare/v0.1.0...HEAD
+[unreleased]: https://github.com/sd2k/grafana-plugin-sdk-rust/compare/v0.2.0...HEAD
+[0.2.0]: https://github.com/sd2k/grafana-plugin-sdk-rust/tag/v0.2.0
 [0.1.0]: https://github.com/sd2k/grafana-plugin-sdk-rust/tag/v0.1.0

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "grafana-plugin-sdk"
-version = "0.1.0"
+version = "0.2.0"
 authors = ["Ben Sully <ben.sully@grafana.com>"]
 license = "MIT/Apache-2.0"
 edition = "2021"
@@ -13,7 +13,7 @@ arrow2 = { version = "0.10.0", features = ["io_ipc"] }
 chrono = "0.4.19"
 futures-core = "0.3.17"
 futures-util = "0.3.17"
-grafana-plugin-sdk-macros = { version = "0.1.0", path = "./grafana-plugin-sdk-macros" }
+grafana-plugin-sdk-macros = { version = "0.2.0", path = "./grafana-plugin-sdk-macros" }
 http = "0.2.5"
 itertools = "0.10.1"
 num-traits = "0.2.14"

--- a/grafana-plugin-sdk-macros/Cargo.toml
+++ b/grafana-plugin-sdk-macros/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "grafana-plugin-sdk-macros"
-version = "0.1.0"
+version = "0.2.0"
 authors = ["Ben Sully <ben.sully@grafana.com>"]
 license = "MIT/Apache-2.0"
 edition = "2018"
@@ -16,7 +16,7 @@ quote = "1.0.10"
 syn = { version = "1.0.81", features = ["full"] }
 
 [dev-dependencies]
-grafana-plugin-sdk = { version = "0.1.0", path = ".." }
+grafana-plugin-sdk = { version = "0.2.0", path = ".." }
 tokio = { version = "1.13.0", features = ["rt-multi-thread"] }
 trybuild = "1.0.52"
 


### PR DESCRIPTION
Bump the crate to v0.2.0.

Changes:

### Added

- Bump arrow2 dependency to 0.10.0, and re-export it as `grafana_plugin_sdk::arrow2`
- Added new `data` field to `SubscribeStreamRequest` and `SubscribeStreamResponse`,
  matching the latest release of the protobuf descriptors.
- More types now impl `FieldType` and `IntoFieldType`, meaning that iterators or vecs of them can be turned into `Field`s:
  - `bool`
  - `SystemTime`
  - `chrono::Date`
  - `chrono::NaiveDate`
  - `chrono::NaiveDateTime`
- The `FieldType` and `IntoFieldType` traits are now public. These are useful when
  writing generic functions to convert iterators, vecs, slices or arrays into `Field`s.

### Changed

- Mark the various `Request` and `Response` structs in the backend part of the SDK as
  `#[non_exhaustive]` since changes to those structs are largely outside of our control;
  the protobuf descriptors may add additional fields, and this allows us to include them
  without breaking our API. Some `Response` types now have new constructors which should
  be used.
- Most of the exported types in the `data` part of the SDK are also now non-exhaustive,
  for the same reason as above. These types now either have separate constructors or
  `Default` impls which can be used to create them.
- Derive `Clone` for various backend structs:
  - `AppInstanceSettings`
  - `DataSourceInstanceSettings`
  - `PluginContext`
  - `Role` (is also now `Copy`)
  - `TimeRange`
  - `User`
- Change the `Iter` associated type of `backend::DataService` to `Stream`, and update
  the return type of `query_data` accordingly. This allows each inner query to be handled
  asynchronously and concurrently in a simple way.
- The `live::Error` type is now an enum and provides more detail on failures.
- The `path` field of `SubscribeStreamRequest`, `RunStreamRequest` and
  `PublishStreamRequest` are now `live::Path` types rather than arbitrary strings.

