### PR TITLE
Move changelog check GitHub action to separate workflow that doesn't run on main

### DIFF
--- a/.github/workflows/changelog.yml
+++ b/.github/workflows/changelog.yml
@@ -1,0 +1,19 @@
+name: Ensure CHANGELOG updated
+
+on:
+  pull_request:
+    types: [ assigned, opened, synchronize, reopened, labeled, unlabeled ]
+    branches: [ main ]
+
+jobs:
+  changelog:
+    name: Ensure changelog updated
+    runs-on: ubuntu-latest
+    steps:
+      - name: Changelog check
+        uses: Zomzog/changelog-checker@v1.2.0
+        with:
+          fileName: CHANGELOG.md
+          noChangelogLabel: no-changelog
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -10,17 +10,6 @@ env:
   CARGO_TERM_COLOR: always
 
 jobs:
-  changelog:
-    name: Ensure changelog updated
-    runs-on: ubuntu-latest
-    steps:
-      - name: Changelog check
-        uses: Zomzog/changelog-checker@v1.2.0
-        with:
-          fileName: CHANGELOG.md
-          noChangelogLabel: no-changelog
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
   check:
     name: Check
     runs-on: ubuntu-latest


### PR DESCRIPTION
Otherwise it checks that the changelog has been updated for commits to `main`, which is obviously silly!