### PR TITLE
Update tonic, tonic-build, tonic-health, prost, prost-build dependencies

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- Dependency bumps:
+  - prost 0.9.0 -> 0.10.0
+  - tonic 0.6.0 -> 0.7.0
+  - tonic-health 0.5.0 -> 0.6.0
+
 ## [0.2.0] - 2022-03-15
 
 ### Added

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,7 +17,7 @@ grafana-plugin-sdk-macros = { version = "0.2.0", path = "./grafana-plugin-sdk-ma
 http = "0.2.5"
 itertools = "0.10.1"
 num-traits = "0.2.14"
-prost = "0.9.0"
+prost = "0.10.0"
 reqwest_lib = { package = "reqwest", version = "0.11.6", optional = true }
 serde = { version = "1.0.130", features = ["derive"] }
 serde_json = { version = "1.0.69", features = ["float_roundtrip", "raw_value"] }
@@ -26,8 +26,8 @@ thiserror = "1.0.30"
 time = { version = "0.3.5", features = ["formatting", "macros"] }
 tokio = { version = "1.13.0", features = ["rt-multi-thread"] }
 tokio-stream = { version = "0.1.8", features = ["net"] }
-tonic = "0.6.1"
-tonic-health = "0.5.0"
+tonic = "0.7.0"
+tonic-health = "0.6.0"
 tracing = "0.1.29"
 tracing-core = "0.1.21"
 tracing-log = "0.1.2"
@@ -45,8 +45,8 @@ tokio = { version = "1.13.0", features = ["rt-multi-thread"] }
 tokio-stream = "0.1.8"
 
 [build-dependencies]
-prost-build = "0.9.0"
-tonic-build = "0.6.0"
+prost-build = "0.10.0"
+tonic-build = "0.7.0"
 
 # docs.rs-specific configuration
 [package.metadata.docs.rs]


### PR DESCRIPTION
This consolidates several dependabot PRs that are interdependent.

Version updates:

- prost 0.9.0 -> 0.10.0
- prost-build 0.9.0 -> 0.10.0
- tonic 0.6.0 -> 0.7.0
- tonic-build 0.6.0 -> 0.7.0
- tonic-health 0.5.0 -> 0.6.0