### PR TITLE
Add more clear constructors for various response structs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,18 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- Added various new constructors for `SubscribeStreamResponse`, `PublishStreamResponse`
+  and `CheckHealthResponse`, reducing the reliance of knowing what the arguments should
+  be.
+
+### Deprecated
+
+- The `CheckHealthResponse::new`, `SubscribeStreamResponse::new` and
+  `PublishStreamResponse::new` methods have been deprecated in favour of their new,
+  more direct constructors.
+
 ### Changed
 
 - Dependency bumps:

--- a/examples/main.rs
+++ b/examples/main.rs
@@ -97,13 +97,13 @@ impl backend::StreamService for MyPluginService {
         &self,
         request: backend::SubscribeStreamRequest,
     ) -> Result<backend::SubscribeStreamResponse, Self::Error> {
-        let status = if request.path.as_str() == "stream" {
-            backend::SubscribeStreamStatus::Ok
+        let response = if request.path.as_str() == "stream" {
+            backend::SubscribeStreamResponse::ok(None)
         } else {
-            backend::SubscribeStreamStatus::NotFound
+            backend::SubscribeStreamResponse::not_found()
         };
         info!(path = %request.path, "Subscribing to stream");
-        Ok(backend::SubscribeStreamResponse::new(status, None))
+        Ok(response)
     }
 
     type Error = StreamError;

--- a/src/backend/diagnostics.rs
+++ b/src/backend/diagnostics.rs
@@ -60,12 +60,55 @@ pub struct CheckHealthResponse {
 
 impl CheckHealthResponse {
     /// Create a new `CheckHealthResponse`.
+    #[deprecated(since = "1.3.0", note = "use ok/error/unknown constructors instead")]
     pub fn new(status: HealthStatus, message: String, json_details: Value) -> Self {
         Self {
             status,
             message,
             json_details,
         }
+    }
+
+    /// Create a `CheckHealthResponse` with status [`HealthStatus::Ok`].
+    ///
+    /// The JSON in `json_details` will be set to `null`; use [`with_json_details`]
+    /// to override it.
+    pub fn ok(message: String) -> Self {
+        Self {
+            status: HealthStatus::Ok,
+            message,
+            json_details: Value::Null,
+        }
+    }
+
+    /// Create a `CheckHealthResponse` with status [`HealthStatus::Error`].
+    ///
+    /// The JSON in `json_details` will be set to `null`; use [`with_json_details`]
+    /// to override it.
+    pub fn error(message: String) -> Self {
+        Self {
+            status: HealthStatus::Error,
+            message,
+            json_details: Value::Null,
+        }
+    }
+
+    /// Create a `CheckHealthResponse` with status [`HealthStatus::Unknown`].
+    ///
+    /// The JSON in `json_details` will be set to `null`; use [`with_json_details`]
+    /// to override it.
+    pub fn unknown(message: String) -> Self {
+        Self {
+            status: HealthStatus::Unknown,
+            message,
+            json_details: Value::Null,
+        }
+    }
+
+    /// Update `self` with the given JSON details, returning a new `CheckHealthResponse`.
+    pub fn with_json_details(mut self, json_details: Value) -> Self {
+        self.json_details = json_details;
+        self
     }
 }
 
@@ -185,11 +228,7 @@ impl From<CollectMetricsResponse> for pluginv2::CollectMetricsResponse {
 ///     ) -> Result<backend::CheckHealthResponse, Self::CheckHealthError> {
 ///         // A real plugin may ensure it could e.g. connect to a database, was configured
 ///         // correctly, etc.
-///         Ok(backend::CheckHealthResponse::new(
-///             backend::HealthStatus::Ok,
-///             "Ok".to_string(),
-///             serde_json::json!({}),
-///         ))
+///         Ok(backend::CheckHealthResponse::ok("Ok".to_string()))
 ///     }
 ///
 ///     type CollectMetricsError = prometheus::Error;

--- a/src/backend/stream.rs
+++ b/src/backend/stream.rs
@@ -100,9 +100,6 @@ impl InitialData {
 /// The response to a stream subscription request.
 ///
 /// This includes a status and some optional initial data for the stream.
-///
-/// If `initial_data` is provided then the requirements in the [`InitialData`] documentation
-/// MUST be upheld.
 #[derive(Debug)]
 #[non_exhaustive]
 pub struct SubscribeStreamResponse {
@@ -113,11 +110,45 @@ pub struct SubscribeStreamResponse {
 }
 
 impl SubscribeStreamResponse {
-    /// Create a new `SubscribeStreamResponse `.
+    /// Create a new `SubscribeStreamResponse`.
+    #[deprecated(
+        since = "1.3.0",
+        note = "use ok/not_found/permission_denied constructors instead"
+    )]
     pub fn new(status: SubscribeStreamStatus, initial_data: Option<InitialData>) -> Self {
         Self {
             status,
             initial_data,
+        }
+    }
+
+    /// Create a `SubscribeStreamResponse` with status [`SubscribeStreamStatus::Ok`].
+    ///
+    /// This is the happy path to be used when a subscription request succeeded.
+    pub fn ok(initial_data: Option<InitialData>) -> Self {
+        Self {
+            status: SubscribeStreamStatus::Ok,
+            initial_data,
+        }
+    }
+
+    /// Create a `SubscribeStreamResponse` with status [`SubscribeStreamStatus::NotFound`].
+    ///
+    /// This should be returned when the caller requested an unknown path.
+    pub fn not_found() -> Self {
+        Self {
+            status: SubscribeStreamStatus::NotFound,
+            initial_data: None,
+        }
+    }
+
+    /// Create a `SubscribeStreamResponse` with status [`SubscribeStreamStatus::PermissionDenied`].
+    ///
+    /// This should be returned when the caller is not permitted to access the requested path.
+    pub fn permission_denied() -> Self {
+        Self {
+            status: SubscribeStreamStatus::PermissionDenied,
+            initial_data: None,
         }
     }
 }
@@ -282,8 +313,42 @@ pub struct PublishStreamResponse {
 
 impl PublishStreamResponse {
     /// Create a new `PublishStreamResponse`.
+    #[deprecated(
+        since = "1.3.0",
+        note = "use ok/not_found/permission_denied constructors instead"
+    )]
     pub fn new(status: PublishStreamStatus, data: serde_json::Value) -> Self {
         Self { status, data }
+    }
+
+    /// Create a `PublishStreamResponse` with status [`PublishStreamStatus::Ok`].
+    ///
+    /// This is the happy path to be used when a publish request succeeded.
+    pub fn ok(data: serde_json::Value) -> Self {
+        Self {
+            status: PublishStreamStatus::Ok,
+            data,
+        }
+    }
+
+    /// Create a `PublishStreamResponse` with status [`PublishStreamStatus::NotFound`].
+    ///
+    /// This should be returned when the caller requested an unknown path.
+    pub fn not_found(details: serde_json::Value) -> Self {
+        Self {
+            status: PublishStreamStatus::NotFound,
+            data: details,
+        }
+    }
+
+    /// Create a `PublishStreamResponse` with status [`PublishStreamStatus::PermissionDenied`].
+    ///
+    /// This should be returned when the caller is not permitted to access the requested path.
+    pub fn permission_denied(details: serde_json::Value) -> Self {
+        Self {
+            status: PublishStreamStatus::PermissionDenied,
+            data: details,
+        }
     }
 }
 
@@ -345,13 +410,13 @@ impl TryFrom<PublishStreamResponse> for pluginv2::PublishStreamResponse {
 ///         &self,
 ///         request: backend::SubscribeStreamRequest,
 ///     ) -> Result<backend::SubscribeStreamResponse, Self::Error> {
-///         let status = if request.path.as_str() == "stream" {
-///             backend::SubscribeStreamStatus::Ok
+///         let response = if request.path.as_str() == "stream" {
+///             backend::SubscribeStreamResponse::ok(None)
 ///         } else {
-///             backend::SubscribeStreamStatus::NotFound
+///             backend::SubscribeStreamResponse::not_found()
 ///         };
 ///         info!(path = %request.path, "Subscribing to stream");
-///         Ok(backend::SubscribeStreamResponse::new(status, None))
+///         Ok(response)
 ///     }
 ///
 ///     type Error = StreamError;


### PR DESCRIPTION
The new constructors make it easier to see what each argument is for
at the callsite, as fewer arguments are required for each call.
