### PR TITLE
Add FlameGraph visualisation type

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased] - ReleaseDate
 
+### Added
+
+- Add `VisType::FlameGraph` variant to indicate that a frame should be visualised using the flame graph panel introduced [here](https://github.com/grafana/grafana/pull/56376).
+
 ## [0.4.2] - 2022-09-19
 
 ## [0.4.1] - 2022-09-19

--- a/crates/grafana-plugin-sdk/src/data/frame/mod.rs
+++ b/crates/grafana-plugin-sdk/src/data/frame/mod.rs
@@ -543,6 +543,8 @@ pub enum VisType {
     Trace,
     /// Node graph visualization.
     NodeGraph,
+    /// Flame graph visualization.
+    FlameGraph,
 }
 
 /// A notification to be displayed in Grafana's UI.


### PR DESCRIPTION
This accompanies the flame graph panel introduced in [this PR](https://github.com/grafana/grafana/pull/56376), similar to [this PR](https://github.com/grafana/grafana-plugin-sdk-go/pull/546) in the Go SDK.
