### PR TITLE
Allow custom types for JSON/secure JSON data of plugins

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,18 +9,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased] - ReleaseDate
 
-- Bump itertools dependency to 0.13.0
-- Bump prost dependency to 0.13.2
-- Bump reqwest dependency to 0.12.7
-- Bump tonic dependency to 0.12.2
-- Bump tonic-health dependency to 0.12.2
-- Increase MSRV to 1.63, due to tokio-util requiring it
-
-## [0.4.3] - 2024-01-18
-
 ### Added
 
-- Plugins can now specify a custom type for the `json_data` and
+- Plugins must now specify a custom type for the `json_data` and
   `decrypted_secure_json_data` fields of their app/datasource instance
   settings, corresponding to the two type parameters of `DataSourceSettings`
   in the `@grafana/data` Javascript library.
@@ -72,6 +63,20 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
           ...
       }
   ```
+
+### Changed
+
+- Bump itertools dependency to 0.13.0
+- Bump prost dependency to 0.13.2
+- Bump reqwest dependency to 0.12.7
+- Bump tonic dependency to 0.12.2
+- Bump tonic-health dependency to 0.12.2
+- Increase MSRV to 1.63, due to tokio-util requiring it
+
+## [0.4.3] - 2024-01-18
+
+### Added
+
 - Add `VisType::FlameGraph` variant to indicate that a frame should be visualised using the flame graph panel introduced [here](https://github.com/grafana/grafana/pull/56376).
 - Add overrideable `DataQueryError::status` method which must return a `DataQueryStatus`. This can be used by datasource implementations to provide more detail about how an error should be handled.
 - Add `arrow-array` support for Field ([#111](https://github.com/grafana/grafana-plugin-sdk-rust/pull/111) by @kerryeon)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,58 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- Plugins can now specify a custom type for the `json_data` and
+  `decrypted_secure_json_data` fields of their app/datasource instance
+  settings, corresponding to the two type parameters of `DataSourceSettings`
+  in the `@grafana/data` Javascript library.
+
+  Plugin structs must now also implement the `GrafanaPlugin` trait, which is used
+  to declare:
+  - the type of the JSON data and secure JSON data
+  - the type of plugin (`PluginType::App` or `PluginType::Datasource`)
+
+  The simplest way to do so is to use the `GrafanaPlugin` derive macro exporter from the library's prelude:
+  
+  ```rust
+  use std::collections::HashMap;
+
+  use grafana_plugin_sdk::prelude::*;
+  use serde::DeserializeOwned;
+
+  #[derive(Debug, DeserializeOwned)]
+  struct DatasourceSettings {
+      max_retries: usize,
+      other_custom_setting: String,
+  }
+  
+  #[derive(Debug, GrafanaPlugin)]
+  #[grafana_plugin(
+      type = "datasource",
+      json_data = "DatasourceSettings",
+      secure_json_data = "HashMap<String, String>",
+  )]
+  struct Plugin {
+      // any plugin data
+  }
+  ```
+
+  Both `json_data` and `secure_json_data` default to `serde_json::Value` if omitted.
+
+  The various `Request` structs in the `backend` module are now type aliases for more complex structs,
+  and require a type parameter which should be `Self`:
+
+  ```rust
+  impl backend::ResourceService for MyPluginService {
+
+      ...
+
+      async fn call_resource(
+          &self,
+          r: backend::CallResourceRequest<Self>,  // Note the new `Self` type parameter.
+      ) -> Result<(Self::InitialResponse, Self::Stream), Self::Error> {
+          ...
+      }
+  ```
 - Add `VisType::FlameGraph` variant to indicate that a frame should be visualised using the flame graph panel introduced [here](https://github.com/grafana/grafana/pull/56376).
 - Add overrideable `DataQueryError::status` method which must return a `DataQueryStatus`. This can be used by datasource implementations to provide more detail about how an error should be handled.
 - Add `arrow-array` support for Field ([#111](https://github.com/grafana/grafana-plugin-sdk-rust/pull/111) by @kerryeon)

--- a/crates/grafana-plugin-sdk-macros/Cargo.toml
+++ b/crates/grafana-plugin-sdk-macros/Cargo.toml
@@ -11,6 +11,7 @@ description = "Convenience macros for the Grafana backend plugin SDK."
 proc-macro = true
 
 [dependencies]
+darling = "0.20.3"
 proc-macro2 = "1.0.60"
 quote = "1.0.28"
 syn = { version = "2.0.18", features = ["full"] }

--- a/crates/grafana-plugin-sdk-macros/tests/ui-fail/duplicate_services.rs
+++ b/crates/grafana-plugin-sdk-macros/tests/ui-fail/duplicate_services.rs
@@ -1,10 +1,11 @@
 #![allow(dead_code, unused_variables)]
 
 mod a {
-    use grafana_plugin_sdk::{backend, data};
+    use grafana_plugin_sdk::{backend, data, prelude::*};
     use serde::Deserialize;
 
-    #[derive(Clone)]
+    #[derive(Clone, GrafanaPlugin)]
+    #[grafana_plugin(plugin_type = "datasource")]
     struct MyPlugin;
 
     #[derive(Debug, Deserialize)]
@@ -38,7 +39,10 @@ mod a {
         type Query = Query;
         type QueryError = QueryError;
         type Stream = backend::BoxDataResponseStream<Self::QueryError>;
-        async fn query_data(&self, request: backend::QueryDataRequest<Self::Query>) -> Self::Stream {
+        async fn query_data(
+            &self,
+            request: backend::QueryDataRequest<Self::Query, Self>,
+        ) -> Self::Stream {
             todo!()
         }
     }
@@ -50,4 +54,3 @@ mod a {
 }
 
 fn main() {}
-

--- a/crates/grafana-plugin-sdk-macros/tests/ui-fail/duplicate_services.stderr
+++ b/crates/grafana-plugin-sdk-macros/tests/ui-fail/duplicate_services.stderr
@@ -1,5 +1,5 @@
 error: `data` set multiple times.
-  --> tests/ui-fail/duplicate_services.rs:46:47
+  --> tests/ui-fail/duplicate_services.rs:50:47
    |
-46 |     #[grafana_plugin_sdk::main(services(data, data))]
+50 |     #[grafana_plugin_sdk::main(services(data, data))]
    |                                               ^^^^

--- a/crates/grafana-plugin-sdk-macros/tests/ui-fail/invalid_init_subscriber.rs
+++ b/crates/grafana-plugin-sdk-macros/tests/ui-fail/invalid_init_subscriber.rs
@@ -1,10 +1,11 @@
 #![allow(dead_code, unused_variables)]
 
 mod a {
-    use grafana_plugin_sdk::{backend, data};
+    use grafana_plugin_sdk::{backend, data, prelude::*};
     use serde::Deserialize;
 
-    #[derive(Clone)]
+    #[derive(Clone, GrafanaPlugin)]
+    #[grafana_plugin(plugin_type = "datasource")]
     struct MyPlugin;
 
     #[derive(Debug, Deserialize)]
@@ -38,7 +39,10 @@ mod a {
         type Query = Query;
         type QueryError = QueryError;
         type Stream = backend::BoxDataResponseStream<Self::QueryError>;
-        async fn query_data(&self, request: backend::QueryDataRequest<Self::Query>) -> Self::Stream {
+        async fn query_data(
+            &self,
+            request: backend::QueryDataRequest<Self::Query, Self>,
+        ) -> Self::Stream {
             todo!()
         }
     }

--- a/crates/grafana-plugin-sdk-macros/tests/ui-fail/invalid_init_subscriber.stderr
+++ b/crates/grafana-plugin-sdk-macros/tests/ui-fail/invalid_init_subscriber.stderr
@@ -1,5 +1,5 @@
 error: `init_subscriber` should be specified as `init_subscriber = true`
-  --> tests/ui-fail/invalid_init_subscriber.rs:46:48
+  --> tests/ui-fail/invalid_init_subscriber.rs:50:48
    |
-46 |     #[grafana_plugin_sdk::main(services(data), init_subscriber(true))]
+50 |     #[grafana_plugin_sdk::main(services(data), init_subscriber(true))]
    |                                                ^^^^^^^^^^^^^^^^^^^^^

--- a/crates/grafana-plugin-sdk-macros/tests/ui-fail/invalid_shutdown_handler.rs
+++ b/crates/grafana-plugin-sdk-macros/tests/ui-fail/invalid_shutdown_handler.rs
@@ -1,10 +1,11 @@
 #![allow(dead_code, unused_variables)]
 
 mod a {
-    use grafana_plugin_sdk::{backend, data};
+    use grafana_plugin_sdk::{backend, data, prelude::*};
     use serde::Deserialize;
 
-    #[derive(Clone)]
+    #[derive(Clone, GrafanaPlugin)]
+    #[grafana_plugin(plugin_type = "datasource")]
     struct MyPlugin;
 
     #[derive(Debug, Deserialize)]
@@ -38,7 +39,10 @@ mod a {
         type Query = Query;
         type QueryError = QueryError;
         type Stream = backend::BoxDataResponseStream<Self::QueryError>;
-        async fn query_data(&self, request: backend::QueryDataRequest<Self::Query>) -> Self::Stream {
+        async fn query_data(
+            &self,
+            request: backend::QueryDataRequest<Self::Query, Self>,
+        ) -> Self::Stream {
             todo!()
         }
     }
@@ -50,10 +54,11 @@ mod a {
 }
 
 mod b {
-    use grafana_plugin_sdk::{backend, data};
+    use grafana_plugin_sdk::{backend, data, prelude::*};
     use serde::Deserialize;
 
-    #[derive(Clone)]
+    #[derive(Clone, GrafanaPlugin)]
+    #[grafana_plugin(plugin_type = "datasource")]
     struct MyPlugin;
 
     #[derive(Debug, Deserialize)]
@@ -87,7 +92,10 @@ mod b {
         type Query = Query;
         type QueryError = QueryError;
         type Stream = backend::BoxDataResponseStream<Self::QueryError>;
-        async fn query_data(&self, request: backend::QueryDataRequest<Self::Query>) -> Self::Stream {
+        async fn query_data(
+            &self,
+            request: backend::QueryDataRequest<Self::Query, Self>,
+        ) -> Self::Stream {
             todo!()
         }
     }

--- a/crates/grafana-plugin-sdk-macros/tests/ui-fail/invalid_shutdown_handler.stderr
+++ b/crates/grafana-plugin-sdk-macros/tests/ui-fail/invalid_shutdown_handler.stderr
@@ -1,11 +1,11 @@
 error: `shutdown_handler` must be a string literal.
-  --> tests/ui-fail/invalid_shutdown_handler.rs:46:67
+  --> tests/ui-fail/invalid_shutdown_handler.rs:50:67
    |
-46 |     #[grafana_plugin_sdk::main(services(data), shutdown_handler = true)]
+50 |     #[grafana_plugin_sdk::main(services(data), shutdown_handler = true)]
    |                                                                   ^^^^
 
 error: `shutdown_handler` should be specified as `shutdown_handler = "127.0.0.1:10001"
-  --> tests/ui-fail/invalid_shutdown_handler.rs:95:48
-   |
-95 |     #[grafana_plugin_sdk::main(services(data), shutdown_handler("127.0.0.1:10001"))]
-   |                                                ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   --> tests/ui-fail/invalid_shutdown_handler.rs:103:48
+    |
+103 |     #[grafana_plugin_sdk::main(services(data), shutdown_handler("127.0.0.1:10001"))]
+    |                                                ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^

--- a/crates/grafana-plugin-sdk-macros/tests/ui-fail/missing_services.rs
+++ b/crates/grafana-plugin-sdk-macros/tests/ui-fail/missing_services.rs
@@ -11,4 +11,3 @@ mod a {
 }
 
 fn main() {}
-

--- a/crates/grafana-plugin-sdk-macros/tests/ui-fail/non_impl_service.rs
+++ b/crates/grafana-plugin-sdk-macros/tests/ui-fail/non_impl_service.rs
@@ -1,7 +1,10 @@
 #![allow(dead_code, unused_variables)]
 
 mod a {
-    #[derive(Clone)]
+    use grafana_plugin_sdk::prelude::*;
+
+    #[derive(Clone, GrafanaPlugin)]
+    #[grafana_plugin(plugin_type = "datasource")]
     struct MyPlugin;
 
     #[grafana_plugin_sdk::main(services(data))]
@@ -11,5 +14,3 @@ mod a {
 }
 
 fn main() {}
-
-

--- a/crates/grafana-plugin-sdk-macros/tests/ui-fail/non_impl_service.stderr
+++ b/crates/grafana-plugin-sdk-macros/tests/ui-fail/non_impl_service.stderr
@@ -1,34 +1,34 @@
 error[E0277]: the trait bound `MyPlugin: DataService` is not satisfied
- --> tests/ui-fail/non_impl_service.rs:7:5
-  |
-7 |     #[grafana_plugin_sdk::main(services(data))]
-  |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ the trait `DataService` is not implemented for `MyPlugin`
-  |
-  = help: the trait `DataService` is implemented for `backend::noop::NoopService`
+  --> tests/ui-fail/non_impl_service.rs:10:5
+   |
+10 |     #[grafana_plugin_sdk::main(services(data))]
+   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ the trait `DataService` is not implemented for `MyPlugin`
+   |
+   = help: the trait `DataService` is implemented for `backend::noop::NoopService`
 note: required by a bound in `grafana_plugin_sdk::backend::Plugin::<D, Q, R, S>::data_service`
- --> $WORKSPACE/crates/grafana-plugin-sdk/src/backend/mod.rs
-  |
-  |     pub fn data_service<T>(self, service: T) -> Plugin<D, T, R, S>
-  |            ------------ required by a bound in this associated function
-  |     where
-  |         T: DataService + Send + Sync + 'static,
-  |            ^^^^^^^^^^^ required by this bound in `Plugin::<D, Q, R, S>::data_service`
-  = note: this error originates in the attribute macro `grafana_plugin_sdk::main` (in Nightly builds, run with -Z macro-backtrace for more info)
+  --> $WORKSPACE/crates/grafana-plugin-sdk/src/backend/mod.rs
+   |
+   |     pub fn data_service<T>(self, service: T) -> Plugin<D, T, R, S>
+   |            ------------ required by a bound in this associated function
+   |     where
+   |         T: DataService + Send + Sync + 'static,
+   |            ^^^^^^^^^^^ required by this bound in `Plugin::<D, Q, R, S>::data_service`
+   = note: this error originates in the attribute macro `grafana_plugin_sdk::main` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error[E0599]: the method `start` exists for struct `Plugin<NoopService, MyPlugin, NoopService, NoopService>`, but its trait bounds were not satisfied
- --> tests/ui-fail/non_impl_service.rs:7:5
-  |
-5 |     struct MyPlugin;
-  |     --------------- doesn't satisfy `MyPlugin: DataService`
-6 |
-7 |     #[grafana_plugin_sdk::main(services(data))]
-  |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ method cannot be called due to unsatisfied trait bounds
-  |
-  = note: the following trait bounds were not satisfied:
-          `MyPlugin: DataService`
+  --> tests/ui-fail/non_impl_service.rs:10:5
+   |
+8  |     struct MyPlugin;
+   |     --------------- doesn't satisfy `MyPlugin: DataService`
+9  |
+10 |     #[grafana_plugin_sdk::main(services(data))]
+   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ method cannot be called due to unsatisfied trait bounds
+   |
+   = note: the following trait bounds were not satisfied:
+           `MyPlugin: DataService`
 note: the trait `DataService` must be implemented
- --> $WORKSPACE/crates/grafana-plugin-sdk/src/backend/data.rs
-  |
-  | pub trait DataService {
-  | ^^^^^^^^^^^^^^^^^^^^^
-  = note: this error originates in the attribute macro `grafana_plugin_sdk::main` (in Nightly builds, run with -Z macro-backtrace for more info)
+  --> $WORKSPACE/crates/grafana-plugin-sdk/src/backend/data.rs
+   |
+   | pub trait DataService: GrafanaPlugin {
+   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   = note: this error originates in the attribute macro `grafana_plugin_sdk::main` (in Nightly builds, run with -Z macro-backtrace for more info)

--- a/crates/grafana-plugin-sdk-macros/tests/ui-pass/basic.rs
+++ b/crates/grafana-plugin-sdk-macros/tests/ui-pass/basic.rs
@@ -1,10 +1,11 @@
 #![allow(dead_code, unused_variables)]
 
 mod a {
-    use grafana_plugin_sdk::{backend, data};
+    use grafana_plugin_sdk::{backend, data, prelude::*};
     use serde::Deserialize;
 
-    #[derive(Clone)]
+    #[derive(Clone, GrafanaPlugin)]
+    #[grafana_plugin(plugin_type = "datasource")]
     struct MyPlugin;
 
     #[derive(Debug, Deserialize)]
@@ -38,7 +39,10 @@ mod a {
         type Query = Query;
         type QueryError = QueryError;
         type Stream = backend::BoxDataResponseStream<Self::QueryError>;
-        async fn query_data(&self, request: backend::QueryDataRequest<Self::Query>) -> Self::Stream {
+        async fn query_data(
+            &self,
+            request: backend::QueryDataRequest<Self::Query, Self>,
+        ) -> Self::Stream {
             todo!()
         }
     }
@@ -52,12 +56,13 @@ mod a {
 mod b {
     use std::sync::Arc;
 
-    use grafana_plugin_sdk::{backend, data};
+    use grafana_plugin_sdk::{backend, data, prelude::*};
     use http::Response;
     use serde::Deserialize;
     use thiserror::Error;
 
-    #[derive(Clone)]
+    #[derive(Clone, GrafanaPlugin)]
+    #[grafana_plugin(plugin_type = "datasource")]
     struct MyPlugin;
 
     #[derive(Debug, Deserialize)]
@@ -91,7 +96,10 @@ mod b {
         type Query = Query;
         type QueryError = QueryError;
         type Stream = backend::BoxDataResponseStream<Self::QueryError>;
-        async fn query_data(&self, request: backend::QueryDataRequest<Self::Query>) -> Self::Stream {
+        async fn query_data(
+            &self,
+            request: backend::QueryDataRequest<Self::Query, Self>,
+        ) -> Self::Stream {
             todo!()
         }
     }
@@ -102,7 +110,7 @@ mod b {
 
         async fn check_health(
             &self,
-            request: backend::CheckHealthRequest,
+            request: backend::CheckHealthRequest<Self>,
         ) -> Result<backend::CheckHealthResponse, Self::CheckHealthError> {
             todo!()
         }
@@ -111,7 +119,7 @@ mod b {
 
         async fn collect_metrics(
             &self,
-            request: backend::CollectMetricsRequest,
+            request: backend::CollectMetricsRequest<Self>,
         ) -> Result<backend::CollectMetricsResponse, Self::CollectMetricsError> {
             todo!()
         }
@@ -121,11 +129,11 @@ mod b {
     enum ResourceError {
         #[error("HTTP error: {0}")]
         Http(#[from] http::Error),
-   
+
         #[error("Path not found")]
         NotFound,
     }
-   
+
     impl backend::ErrIntoHttpResponse for ResourceError {}
 
     #[backend::async_trait]
@@ -133,7 +141,10 @@ mod b {
         type Error = ResourceError;
         type InitialResponse = Response<Vec<u8>>;
         type Stream = backend::BoxResourceStream<Self::Error>;
-        async fn call_resource(&self, r: backend::CallResourceRequest) -> Result<(Self::InitialResponse, Self::Stream), Self::Error> {
+        async fn call_resource(
+            &self,
+            r: backend::CallResourceRequest<Self>,
+        ) -> Result<(Self::InitialResponse, Self::Stream), Self::Error> {
             todo!()
         }
     }
@@ -143,18 +154,21 @@ mod b {
         type JsonValue = ();
         async fn subscribe_stream(
             &self,
-            request: backend::SubscribeStreamRequest,
+            request: backend::SubscribeStreamRequest<Self>,
         ) -> Result<backend::SubscribeStreamResponse, Self::Error> {
             todo!()
         }
         type Error = Arc<dyn std::error::Error>;
         type Stream = backend::BoxRunStream<Self::Error>;
-        async fn run_stream(&self, _request: backend::RunStreamRequest) -> Result<Self::Stream, Self::Error> {
+        async fn run_stream(
+            &self,
+            _request: backend::RunStreamRequest<Self>,
+        ) -> Result<Self::Stream, Self::Error> {
             todo!()
         }
         async fn publish_stream(
             &self,
-            _request: backend::PublishStreamRequest,
+            _request: backend::PublishStreamRequest<Self>,
         ) -> Result<backend::PublishStreamResponse, Self::Error> {
             todo!()
         }

--- a/crates/grafana-plugin-sdk-macros/tests/ui-pass/init_subscriber.rs
+++ b/crates/grafana-plugin-sdk-macros/tests/ui-pass/init_subscriber.rs
@@ -1,10 +1,11 @@
 #![allow(dead_code, unused_variables)]
 
 mod a {
-    use grafana_plugin_sdk::{backend, data};
+    use grafana_plugin_sdk::{backend, data, prelude::*};
     use serde::Deserialize;
 
-    #[derive(Clone)]
+    #[derive(Clone, GrafanaPlugin)]
+    #[grafana_plugin(plugin_type = "datasource")]
     struct MyPlugin;
 
     #[derive(Debug, Deserialize)]
@@ -38,19 +39,18 @@ mod a {
         type Query = Query;
         type QueryError = QueryError;
         type Stream = backend::BoxDataResponseStream<Self::QueryError>;
-        async fn query_data(&self, request: backend::QueryDataRequest<Self::Query>) -> Self::Stream {
+        async fn query_data(
+            &self,
+            request: backend::QueryDataRequest<Self::Query, Self>,
+        ) -> Self::Stream {
             todo!()
         }
     }
 
-    #[grafana_plugin_sdk::main(
-        services(data),
-        init_subscriber = true,
-    )]
+    #[grafana_plugin_sdk::main(services(data), init_subscriber = true)]
     async fn plugin() -> MyPlugin {
         MyPlugin
     }
 }
 
 fn main() {}
-

--- a/crates/grafana-plugin-sdk-macros/tests/ui-pass/shutdown_handler.rs
+++ b/crates/grafana-plugin-sdk-macros/tests/ui-pass/shutdown_handler.rs
@@ -1,10 +1,11 @@
 #![allow(dead_code, unused_variables)]
 
 mod a {
-    use grafana_plugin_sdk::{backend, data};
+    use grafana_plugin_sdk::{backend, data, prelude::*};
     use serde::Deserialize;
 
-    #[derive(Clone)]
+    #[derive(Clone, GrafanaPlugin)]
+    #[grafana_plugin(plugin_type = "datasource")]
     struct MyPlugin;
 
     #[derive(Debug, Deserialize)]
@@ -38,19 +39,18 @@ mod a {
         type Query = Query;
         type QueryError = QueryError;
         type Stream = backend::BoxDataResponseStream<Self::QueryError>;
-        async fn query_data(&self, request: backend::QueryDataRequest<Self::Query>) -> Self::Stream {
+        async fn query_data(
+            &self,
+            request: backend::QueryDataRequest<Self::Query, Self>,
+        ) -> Self::Stream {
             todo!()
         }
     }
 
-    #[grafana_plugin_sdk::main(
-        services(data),
-        shutdown_handler = "127.0.0.1:10001",
-    )]
+    #[grafana_plugin_sdk::main(services(data), shutdown_handler = "127.0.0.1:10001")]
     async fn plugin() -> MyPlugin {
         MyPlugin
     }
 }
 
 fn main() {}
-

--- a/crates/grafana-plugin-sdk/examples/main.rs
+++ b/crates/grafana-plugin-sdk/examples/main.rs
@@ -21,7 +21,18 @@ use grafana_plugin_sdk::{
     prelude::*,
 };
 
-#[derive(Clone, Debug, Default)]
+#[derive(Clone, Debug, Deserialize)]
+struct MyJsonData {
+    backend_url: String,
+    max_retries: usize,
+}
+
+#[derive(Clone, Debug, Default, GrafanaPlugin)]
+#[grafana_plugin(
+    plugin_type = "app",
+    json_data = "MyJsonData",
+    secure_json_data = "serde_json::Value"
+)]
 struct MyPluginService(Arc<AtomicUsize>);
 
 impl MyPluginService {
@@ -40,15 +51,16 @@ struct Query {
 }
 
 #[derive(Debug, Error)]
-#[error("Error querying backend for query {ref_id}: {source}")]
-struct QueryError {
-    source: data::Error,
-    ref_id: String,
+enum QueryError {
+    #[error("Error querying backend for query {ref_id}: {source}")]
+    Backend { source: data::Error, ref_id: String },
 }
 
 impl backend::DataQueryError for QueryError {
     fn ref_id(self) -> String {
-        self.ref_id
+        match self {
+            Self::Backend { ref_id, .. } => ref_id,
+        }
     }
 
     fn status(&self) -> backend::DataQueryStatus {
@@ -61,41 +73,51 @@ impl backend::DataService for MyPluginService {
     type Query = Query;
     type QueryError = QueryError;
     type Stream = backend::BoxDataResponseStream<Self::QueryError>;
-    async fn query_data(&self, request: backend::QueryDataRequest<Self::Query>) -> Self::Stream {
+    async fn query_data(
+        &self,
+        request: backend::QueryDataRequest<Self::Query, Self>,
+    ) -> Self::Stream {
+        let instance_settings = request.plugin_context.instance_settings;
         Box::pin(
             request
                 .queries
                 .into_iter()
-                .map(|x: DataQuery<Self::Query>| async move {
-                    // We can see the user's query in `x.query`:
-                    debug!(
-                        expression = x.query.expression,
-                        other_user_input = x.query.other_user_input,
-                        "Got backend query",
-                    );
-                    // Here we create a single response Frame for each query.
-                    // Frames can be created from iterators of fields using [`IntoFrame`].
-                    Ok(backend::DataResponse::new(
-                        x.ref_id.clone(),
-                        vec![[
-                            // Fields can be created from iterators of a variety of
-                            // relevant datatypes.
-                            [
-                                Utc.with_ymd_and_hms(2021, 1, 1, 12, 0, 0).single().unwrap(),
-                                Utc.with_ymd_and_hms(2021, 1, 1, 12, 0, 1).single().unwrap(),
-                                Utc.with_ymd_and_hms(2021, 1, 1, 12, 0, 2).single().unwrap(),
+                .map(|x: DataQuery<Self::Query>| {
+                    let instance_settings = instance_settings.clone();
+                    async move {
+                        let json_data = instance_settings.json_data;
+                        // We can see the user's query in `x.query`:
+                        debug!(
+                            expression = x.query.expression,
+                            other_user_input = x.query.other_user_input,
+                            ?json_data.backend_url,
+                            ?json_data.max_retries,
+                            "Got backend query",
+                        );
+                        // Here we create a single response Frame for each query.
+                        // Frames can be created from iterators of fields using [`IntoFrame`].
+                        Ok(backend::DataResponse::new(
+                            x.ref_id.clone(),
+                            vec![[
+                                // Fields can be created from iterators of a variety of
+                                // relevant datatypes.
+                                [
+                                    Utc.with_ymd_and_hms(2021, 1, 1, 12, 0, 0).single().unwrap(),
+                                    Utc.with_ymd_and_hms(2021, 1, 1, 12, 0, 1).single().unwrap(),
+                                    Utc.with_ymd_and_hms(2021, 1, 1, 12, 0, 2).single().unwrap(),
+                                ]
+                                .into_field("time"),
+                                [1_u32, 2, 3].into_field("x"),
+                                ["a", "b", "c"].into_field("y"),
                             ]
-                            .into_field("time"),
-                            [1_u32, 2, 3].into_field("x"),
-                            ["a", "b", "c"].into_field("y"),
-                        ]
-                        .into_frame("foo")
-                        .check()
-                        .map_err(|source| QueryError {
-                            ref_id: x.ref_id,
-                            source,
-                        })?],
-                    ))
+                            .into_frame("foo")
+                            .check()
+                            .map_err(|source| QueryError::Backend {
+                                ref_id: x.ref_id,
+                                source,
+                            })?],
+                        ))
+                    }
                 })
                 .collect::<FuturesOrdered<_>>(),
         )
@@ -118,7 +140,7 @@ impl backend::StreamService for MyPluginService {
     type JsonValue = ();
     async fn subscribe_stream(
         &self,
-        request: backend::SubscribeStreamRequest,
+        request: backend::SubscribeStreamRequest<Self>,
     ) -> Result<backend::SubscribeStreamResponse, Self::Error> {
         let response = if request.path.as_str() == "stream" {
             backend::SubscribeStreamResponse::ok(None)
@@ -133,7 +155,7 @@ impl backend::StreamService for MyPluginService {
     type Stream = backend::BoxRunStream<Self::Error>;
     async fn run_stream(
         &self,
-        _request: backend::RunStreamRequest,
+        _request: backend::RunStreamRequest<Self>,
     ) -> Result<Self::Stream, Self::Error> {
         info!("Running stream");
         let mut x = 0u32;
@@ -157,7 +179,7 @@ impl backend::StreamService for MyPluginService {
 
     async fn publish_stream(
         &self,
-        _request: backend::PublishStreamRequest,
+        _request: backend::PublishStreamRequest<Self>,
     ) -> Result<backend::PublishStreamResponse, Self::Error> {
         info!("Publishing to stream");
         todo!()
@@ -197,7 +219,7 @@ impl backend::ResourceService for MyPluginService {
     type Stream = backend::BoxResourceStream<Self::Error>;
     async fn call_resource(
         &self,
-        r: backend::CallResourceRequest,
+        r: backend::CallResourceRequest<Self>,
     ) -> Result<(Self::InitialResponse, Self::Stream), Self::Error> {
         let count = Arc::clone(&self.0);
         let response_and_stream = match r.request.uri().path() {

--- a/crates/grafana-plugin-sdk/src/backend/data.rs
+++ b/crates/grafana-plugin-sdk/src/backend/data.rs
@@ -1,14 +1,16 @@
 //! SDK types and traits relevant to plugins that query data.
-use std::{collections::HashMap, pin::Pin, time::Duration};
+use std::{collections::HashMap, fmt, pin::Pin, time::Duration};
 
 use futures_core::Stream;
 use futures_util::StreamExt;
 use serde::de::DeserializeOwned;
 
 use crate::{
-    backend::{self, ConvertFromError, TimeRange},
+    backend::{self, ConvertFromError, InstanceSettings, TimeRange},
     data, pluginv2,
 };
+
+use super::{GrafanaPlugin, PluginType};
 
 /// A request for data made by Grafana.
 ///
@@ -16,16 +18,19 @@ use crate::{
 /// while the actual plugins themselves are in `queries`.
 #[derive(Debug)]
 #[non_exhaustive]
-pub struct QueryDataRequest<Q>
+pub struct InnerQueryDataRequest<Q, IS, JsonData, SecureJsonData>
 where
     Q: DeserializeOwned,
+    JsonData: fmt::Debug + DeserializeOwned,
+    SecureJsonData: DeserializeOwned,
+    IS: InstanceSettings<JsonData, SecureJsonData>,
 {
     /// Details of the plugin instance from which the request originated.
     ///
     /// If the request originates from a datasource instance, this will
     /// include details about the datasource instance in the
     /// `data_source_instance_settings` field.
-    pub plugin_context: backend::PluginContext,
+    pub plugin_context: backend::PluginContext<IS, JsonData, SecureJsonData>,
     /// Headers included along with the request by Grafana.
     pub headers: HashMap<String, String>,
     /// The queries requested by a user or alert.
@@ -36,9 +41,13 @@ where
     pub queries: Vec<DataQuery<Q>>,
 }
 
-impl<Q> TryFrom<pluginv2::QueryDataRequest> for QueryDataRequest<Q>
+impl<Q, IS, JsonData, SecureJsonData> TryFrom<pluginv2::QueryDataRequest>
+    for InnerQueryDataRequest<Q, IS, JsonData, SecureJsonData>
 where
     Q: DeserializeOwned,
+    JsonData: fmt::Debug + DeserializeOwned,
+    SecureJsonData: DeserializeOwned,
+    IS: InstanceSettings<JsonData, SecureJsonData>,
 {
     type Error = ConvertFromError;
     fn try_from(other: pluginv2::QueryDataRequest) -> Result<Self, Self::Error> {
@@ -56,6 +65,29 @@ where
         })
     }
 }
+
+/// A request for data made by Grafana.
+///
+/// Details of the request source can be found in `plugin_context`,
+/// while the actual plugins themselves are in `queries`.
+///
+/// This is a convenience type alias to hide some of the complexity of
+/// the various generics involved.
+///
+/// The type parameter `Q` is the type of the query: generally you can use
+/// `Self::Query` here.
+///
+/// The type parameter `T` is the type of the plugin implementation itself,
+/// which must implement [`ConfiguredPlugin`].
+pub type QueryDataRequest<Q, T> = InnerQueryDataRequest<
+    Q,
+    <<T as GrafanaPlugin>::PluginType as PluginType<
+        <T as GrafanaPlugin>::JsonData,
+        <T as GrafanaPlugin>::SecureJsonData,
+    >>::InstanceSettings,
+    <T as GrafanaPlugin>::JsonData,
+    <T as GrafanaPlugin>::SecureJsonData,
+>;
 
 /// A query made by Grafana to the plugin as part of a [`QueryDataRequest`].
 ///
@@ -272,6 +304,8 @@ impl DataQueryStatus {
 /// use grafana_plugin_sdk::{backend, data, prelude::*};
 /// use thiserror::Error;
 ///
+/// #[derive(Clone, Debug, GrafanaPlugin)]
+/// #[grafana_plugin(plugin_type = "datasource")]
 /// struct MyPlugin;
 ///
 /// /// An error that may occur during a query.
@@ -318,7 +352,7 @@ impl DataQueryStatus {
 ///     ///
 ///     /// Our plugin must respond to each query and return an iterator of `DataResponse`s,
 ///     /// which themselves can contain zero or more `Frame`s.
-///     async fn query_data(&self, request: backend::QueryDataRequest<Self::Query>) -> Self::Stream {
+///     async fn query_data(&self, request: backend::QueryDataRequest<Self::Query, Self>) -> Self::Stream {
 ///         Box::pin(
 ///             request
 ///                 .queries
@@ -349,7 +383,7 @@ impl DataQueryStatus {
 /// }
 /// ```
 #[tonic::async_trait]
-pub trait DataService {
+pub trait DataService: GrafanaPlugin {
     /// The type of the JSON query sent from Grafana to the plugin.
     type Query: DeserializeOwned + Send + Sync;
 
@@ -369,7 +403,7 @@ pub trait DataService {
     ///
     /// The request will contain zero or more queries, as well as information about the
     /// origin of the queries (such as the datasource instance) in the `plugin_context` field.
-    async fn query_data(&self, request: QueryDataRequest<Self::Query>) -> Self::Stream;
+    async fn query_data(&self, request: QueryDataRequest<Self::Query, Self>) -> Self::Stream;
 }
 
 /// Type alias for a boxed iterator of query responses, useful for returning from [`DataService::query_data`].

--- a/crates/grafana-plugin-sdk/src/backend/data.rs
+++ b/crates/grafana-plugin-sdk/src/backend/data.rs
@@ -138,7 +138,7 @@ where
                 .time_range
                 .map(TimeRange::from)
                 .ok_or(ConvertFromError::MissingTimeRange)?,
-            query: backend::read_json(&other.json)?,
+            query: backend::read_json_query(&other.json)?,
         })
     }
 }

--- a/crates/grafana-plugin-sdk/src/backend/diagnostics.rs
+++ b/crates/grafana-plugin-sdk/src/backend/diagnostics.rs
@@ -358,13 +358,14 @@ where
         request: tonic::Request<pluginv2::CheckHealthRequest>,
     ) -> Result<tonic::Response<pluginv2::CheckHealthResponse>, tonic::Status> {
         let response = match request.into_inner().try_into() {
-            Ok(request) => DiagnosticsService::check_health(self, request).await,
-            Err(e) => Ok(CheckHealthResponse::error(format!(
-                "error converting check health request: {e}"
-            ))
-            .with_json_details(serde_json::to_value(e).unwrap_or(serde_json::Value::Null))),
-        }
-        .map_err(|e| tonic::Status::internal(e.to_string()))?;
+            Ok(request) => DiagnosticsService::check_health(self, request)
+                .await
+                .unwrap_or_else(|e| CheckHealthResponse::error(e.to_string())),
+            Err(e) => {
+                CheckHealthResponse::error(format!("error converting check health request: {e}"))
+                    .with_json_details(serde_json::to_value(e).unwrap_or(serde_json::Value::Null))
+            }
+        };
         Ok(tonic::Response::new(response.into()))
     }
 

--- a/crates/grafana-plugin-sdk/src/backend/mod.rs
+++ b/crates/grafana-plugin-sdk/src/backend/mod.rs
@@ -733,7 +733,7 @@ where
     serde_json::from_slice(jdoc)
 }
 
- fn read_json_query<T>(jdoc: &[u8]) -> ConvertFromResult<T>
+fn read_json_query<T>(jdoc: &[u8]) -> ConvertFromResult<T>
 where
     T: DeserializeOwned,
 {

--- a/crates/grafana-plugin-sdk/src/backend/mod.rs
+++ b/crates/grafana-plugin-sdk/src/backend/mod.rs
@@ -37,7 +37,8 @@ use thiserror::Error;
 use tonic::transport::Server;
 use tracing::info;
 
-#[derive(Clone, Debug)]
+#[derive(Clone, Debug, GrafanaPlugin)]
+#[grafana_plugin(plugin_type = "datasource")]
 struct MyPlugin;
 
 /// An error that may occur during a query.
@@ -84,7 +85,7 @@ impl backend::DataService for MyPlugin {
     ///
     /// Our plugin must respond to each query and return an iterator of `DataResponse`s,
     /// which themselves can contain zero or more `Frame`s.
-    async fn query_data(&self, request: backend::QueryDataRequest<Self::Query>) -> Self::Stream {
+    async fn query_data(&self, request: backend::QueryDataRequest<Self::Query, Self>) -> Self::Stream {
         Box::pin(
             request
                 .queries
@@ -124,7 +125,9 @@ async fn plugin() -> MyPlugin {
 
 [tonic]: https://github.com/hyperium/tonic
 */
-use std::{collections::HashMap, fmt::Debug, io, net::SocketAddr, str::FromStr};
+use std::{
+    collections::HashMap, fmt::Debug, io, marker::PhantomData, net::SocketAddr, str::FromStr,
+};
 
 use chrono::prelude::*;
 use futures_util::FutureExt;
@@ -202,6 +205,10 @@ impl ShutdownHandler {
     }
 }
 
+mod sealed {
+    pub trait Sealed {}
+}
+
 /// Main entrypoint into the Grafana plugin SDK.
 ///
 /// A `Plugin` handles the negotiation with Grafana, adding gRPC health checks,
@@ -244,7 +251,8 @@ impl ShutdownHandler {
 /// use grafana_plugin_sdk::{backend, prelude::*};
 /// use thiserror::Error;
 ///
-/// #[derive(Clone)]
+/// #[derive(Clone, GrafanaPlugin)]
+/// #[grafana_plugin(plugin_type = "datasource")]
 /// struct MyPlugin;
 ///
 /// /// An error that may occur during a query.
@@ -290,7 +298,7 @@ impl ShutdownHandler {
 ///     ///
 ///     /// Our plugin must respond to each query and return an iterator of `DataResponse`s,
 ///     /// which themselves can contain zero or more `Frame`s.
-///     async fn query_data(&self, request: backend::QueryDataRequest<Self::Query>) -> Self::Stream {
+///     async fn query_data(&self, request: backend::QueryDataRequest<Self::Query, Self>) -> Self::Stream {
 ///         Box::pin(
 ///             request
 ///                 .queries
@@ -614,6 +622,9 @@ pub enum ConvertFromError {
     /// The `plugin_context` was missing from the request.
     #[error("plugin_context missing from request")]
     MissingPluginContext,
+    /// The app or datasource instance settings were missing from the request.
+    #[error("instance settings missing from request")]
+    MissingInstanceSettings,
     /// The JSON provided by Grafana was invalid.
     #[error("invalid JSON (got {json}): {err}")]
     InvalidJson {
@@ -621,6 +632,20 @@ pub enum ConvertFromError {
         err: serde_json::Error,
         /// The JSON for which deserialization was attempted.
         json: String,
+    },
+    /// The plugin's 'secure' JSON data could not be converted into
+    /// the backend representation.
+    #[error(
+        "invalid secure JSON (found keys: {keys}): {err}",
+        keys = secure_json_keys.join(", ")
+    )]
+    InvalidSecureJson {
+        /// The underlying JSON error.
+        err: serde_json::Error,
+        /// The keys found in the underlying decrypted secure JSON.
+        ///
+        /// Values are not shown because they are likely to be secret.
+        secure_json_keys: Vec<String>,
     },
     /// The frame provided by Grafana was malformed.
     #[error("invalid frame: {source}")]
@@ -773,26 +798,61 @@ impl TryFrom<pluginv2::User> for User {
     }
 }
 
+fn convert_secure_json_data<T: DeserializeOwned>(
+    secure_json: &HashMap<String, String>,
+) -> Result<T, ConvertFromError> {
+    serde_json::from_value(Value::Object(serde_json::Map::from_iter(
+        secure_json
+            .iter()
+            .map(|(k, v)| (k.clone(), Value::String(v.clone()))),
+    )))
+    .map_err(|e| ConvertFromError::InvalidSecureJson {
+        err: e,
+        secure_json_keys: secure_json.keys().cloned().collect(),
+    })
+}
+
+/// The instance settings for an app or data source instance.
+pub trait InstanceSettings<JsonData, SecureJsonData>: Sized + sealed::Sealed
+where
+    JsonData: DeserializeOwned,
+    SecureJsonData: DeserializeOwned,
+{
+    #[doc(hidden)]
+    fn from_proto(
+        app_instance_settings: Option<pluginv2::AppInstanceSettings>,
+        datasource_instance_settings: Option<pluginv2::DataSourceInstanceSettings>,
+        plugin_id: String,
+    ) -> Result<Self, ConvertFromError>;
+    /// Get the JSON data for the app or data source instance.
+    fn json_data(&self) -> &JsonData;
+    /// Get the decrypted secure JSON data for the app or data source instance.
+    fn decrypted_secure_json_data(&self) -> &SecureJsonData;
+}
+
 /// Settings for an app instance.
 ///
 /// An app instance is an app plugin of a certain type that has been configured
 /// and enabled in a Grafana organisation.
 #[derive(Clone)]
 #[non_exhaustive]
-pub struct AppInstanceSettings {
+pub struct AppInstanceSettings<JsonData, SecureJsonData> {
     /// Includes the non-secret settings of the app instance (excluding datasource config).
-    pub json_data: Value,
+    pub json_data: JsonData,
     /// Key-value pairs where the encrypted configuration in Grafana server have been
     /// decrypted before passing them to the plugin.
     ///
     /// This data is not accessible to the Grafana frontend after it has been set, and should
     /// be used for any secrets (such as API keys or passwords).
-    pub decrypted_secure_json_data: HashMap<String, String>,
+    pub decrypted_secure_json_data: SecureJsonData,
     /// The last time the configuration for the app plugin instance was updated.
     pub updated: DateTime<Utc>,
 }
 
-impl Debug for AppInstanceSettings {
+impl<JsonData, SecureJsonData> Debug for AppInstanceSettings<JsonData, SecureJsonData>
+where
+    JsonData: Debug,
+{
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         f.debug_struct("AppInstanceSettings")
             .field("json_data", &self.json_data)
@@ -802,21 +862,68 @@ impl Debug for AppInstanceSettings {
     }
 }
 
-impl TryFrom<pluginv2::AppInstanceSettings> for AppInstanceSettings {
-    type Error = ConvertFromError;
-    fn try_from(other: pluginv2::AppInstanceSettings) -> Result<Self, Self::Error> {
-        Ok(Self {
-            decrypted_secure_json_data: other.decrypted_secure_json_data,
-            json_data: read_json(&other.json_data)?,
-            updated: Utc
-                .timestamp_millis_opt(other.last_updated_ms)
-                .single()
-                .ok_or(ConvertFromError::InvalidTimestamp {
-                    timestamp: other.last_updated_ms,
-                })?,
-        })
+impl<JsonData, SecureJsonData> InstanceSettings<JsonData, SecureJsonData>
+    for AppInstanceSettings<JsonData, SecureJsonData>
+where
+    JsonData: DeserializeOwned,
+    SecureJsonData: DeserializeOwned,
+{
+    fn from_proto(
+        app_instance_settings: Option<pluginv2::AppInstanceSettings>,
+        _datasource_instance_settings: Option<pluginv2::DataSourceInstanceSettings>,
+        _plugin_id: String,
+    ) -> Result<Self, ConvertFromError> {
+        if let Some(proto) = app_instance_settings {
+            Ok(Self {
+                decrypted_secure_json_data: convert_secure_json_data(
+                    &proto.decrypted_secure_json_data,
+                )?,
+                json_data: read_json(&proto.json_data)?,
+                updated: Utc
+                    .timestamp_millis_opt(proto.last_updated_ms)
+                    .single()
+                    .ok_or(ConvertFromError::InvalidTimestamp {
+                        timestamp: proto.last_updated_ms,
+                    })?,
+            })
+        } else {
+            Err(ConvertFromError::MissingInstanceSettings)
+        }
+    }
+
+    fn json_data(&self) -> &JsonData {
+        &self.json_data
+    }
+
+    fn decrypted_secure_json_data(&self) -> &SecureJsonData {
+        &self.decrypted_secure_json_data
     }
 }
+
+impl<JsonData, SecureJsonData> sealed::Sealed for AppInstanceSettings<JsonData, SecureJsonData> {}
+
+// impl<JsonData, SecureJsonData> TryFrom<pluginv2::AppInstanceSettings>
+//     for AppInstanceSettings<JsonData, SecureJsonData>
+// where
+//     JsonData: DeserializeOwned,
+//     SecureJsonData: DeserializeOwned,
+// {
+//     type Error = ConvertFromError;
+//     fn try_from(other: pluginv2::AppInstanceSettings) -> Result<Self, Self::Error> {
+//         Ok(Self {
+//             decrypted_secure_json_data: convert_secure_json_data(
+//                 &other.decrypted_secure_json_data,
+//             )?,
+//             json_data: read_json(&other.json_data)?,
+//             updated: Utc
+//                 .timestamp_millis_opt(other.last_updated_ms)
+//                 .single()
+//                 .ok_or(ConvertFromError::InvalidTimestamp {
+//                     timestamp: other.last_updated_ms,
+//                 })?,
+//         })
+//     }
+// }
 
 /// Settings for a datasource instance.
 ///
@@ -826,7 +933,7 @@ impl TryFrom<pluginv2::AppInstanceSettings> for AppInstanceSettings {
 /// datasource instances configured in a Grafana organisation.
 #[derive(Clone)]
 #[non_exhaustive]
-pub struct DataSourceInstanceSettings {
+pub struct DataSourceInstanceSettings<JsonData, SecureJsonData> {
     /// The Grafana assigned numeric identifier of the the datasource instance.
     pub id: i64,
 
@@ -861,20 +968,23 @@ pub struct DataSourceInstanceSettings {
     /// The raw DataSourceConfig as JSON as stored by the Grafana server.
     ///
     /// It repeats the properties in this object and includes custom properties.
-    pub json_data: Value,
+    pub json_data: JsonData,
 
     /// Key-value pairs where the encrypted configuration in Grafana server have been
     /// decrypted before passing them to the plugin.
     ///
     /// This data is not accessible to the Grafana frontend after it has been set, and should
     /// be used for any secrets (such as API keys or passwords).
-    pub decrypted_secure_json_data: HashMap<String, String>,
+    pub decrypted_secure_json_data: SecureJsonData,
 
     /// The last time the configuration for the datasource instance was updated.
     pub updated: DateTime<Utc>,
 }
 
-impl Debug for DataSourceInstanceSettings {
+impl<JsonData, SecureJsonData> Debug for DataSourceInstanceSettings<JsonData, SecureJsonData>
+where
+    JsonData: Debug,
+{
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         f.debug_struct("DataSourceInstanceSettings")
             .field("id", &self.id)
@@ -893,37 +1003,101 @@ impl Debug for DataSourceInstanceSettings {
     }
 }
 
-impl TryFrom<(pluginv2::DataSourceInstanceSettings, String)> for DataSourceInstanceSettings {
-    type Error = ConvertFromError;
-    fn try_from(
-        (other, type_): (pluginv2::DataSourceInstanceSettings, String),
-    ) -> Result<Self, Self::Error> {
-        Ok(Self {
-            id: other.id,
-            uid: other.uid,
-            type_,
-            name: other.name,
-            url: other.url,
-            user: other.user,
-            database: other.database,
-            basic_auth_enabled: other.basic_auth_enabled,
-            basic_auth_user: other.basic_auth_user,
-            decrypted_secure_json_data: other.decrypted_secure_json_data,
-            json_data: read_json(&other.json_data)?,
-            updated: Utc
-                .timestamp_millis_opt(other.last_updated_ms)
-                .single()
-                .ok_or(ConvertFromError::InvalidTimestamp {
-                    timestamp: other.last_updated_ms,
-                })?,
-        })
+impl<JsonData, SecureJsonData> InstanceSettings<JsonData, SecureJsonData>
+    for DataSourceInstanceSettings<JsonData, SecureJsonData>
+where
+    JsonData: DeserializeOwned,
+    SecureJsonData: DeserializeOwned,
+{
+    fn from_proto(
+        _app_instance_settings: Option<pluginv2::AppInstanceSettings>,
+        datasource_instance_settings: Option<pluginv2::DataSourceInstanceSettings>,
+        plugin_id: String,
+    ) -> Result<Self, ConvertFromError> {
+        if let Some(proto) = datasource_instance_settings {
+            Ok(Self {
+                id: proto.id,
+                uid: proto.uid,
+                type_: plugin_id,
+                name: proto.name,
+                url: proto.url,
+                user: proto.user,
+                database: proto.database,
+                basic_auth_enabled: proto.basic_auth_enabled,
+                basic_auth_user: proto.basic_auth_user,
+                decrypted_secure_json_data: convert_secure_json_data(
+                    &proto.decrypted_secure_json_data,
+                )?,
+                json_data: read_json(&proto.json_data)?,
+                updated: Utc
+                    .timestamp_millis_opt(proto.last_updated_ms)
+                    .single()
+                    .ok_or(ConvertFromError::InvalidTimestamp {
+                        timestamp: proto.last_updated_ms,
+                    })?,
+            })
+        } else {
+            Err(ConvertFromError::MissingInstanceSettings)
+        }
+    }
+
+    fn json_data(&self) -> &JsonData {
+        &self.json_data
+    }
+
+    fn decrypted_secure_json_data(&self) -> &SecureJsonData {
+        &self.decrypted_secure_json_data
     }
 }
+
+impl<JsonData, SecureJsonData> sealed::Sealed
+    for DataSourceInstanceSettings<JsonData, SecureJsonData>
+{
+}
+
+// impl<JsonData, SecureJsonData> TryFrom<(pluginv2::DataSourceInstanceSettings, String)>
+//     for DataSourceInstanceSettings<JsonData, SecureJsonData>
+// where
+//     JsonData: DeserializeOwned,
+//     SecureJsonData: DeserializeOwned,
+// {
+//     type Error = ConvertFromError;
+//     fn try_from(
+//         (other, type_): (pluginv2::DataSourceInstanceSettings, String),
+//     ) -> Result<Self, Self::Error> {
+//         Ok(Self {
+//             id: other.id,
+//             uid: other.uid,
+//             type_,
+//             name: other.name,
+//             url: other.url,
+//             user: other.user,
+//             database: other.database,
+//             basic_auth_enabled: other.basic_auth_enabled,
+//             basic_auth_user: other.basic_auth_user,
+//             decrypted_secure_json_data: convert_secure_json_data(
+//                 &other.decrypted_secure_json_data,
+//             )?,
+//             json_data: read_json(&other.json_data)?,
+//             updated: Utc
+//                 .timestamp_millis_opt(other.last_updated_ms)
+//                 .single()
+//                 .ok_or(ConvertFromError::InvalidTimestamp {
+//                     timestamp: other.last_updated_ms,
+//                 })?,
+//         })
+//     }
+// }
 
 /// Holds contextual information about a plugin request: Grafana org, user, and plugin instance settings.
 #[derive(Clone, Debug)]
 #[non_exhaustive]
-pub struct PluginContext {
+pub struct PluginContext<IS, JsonData = Value, SecureJsonData = Value>
+where
+    JsonData: Debug + DeserializeOwned,
+    SecureJsonData: DeserializeOwned,
+    IS: InstanceSettings<JsonData, SecureJsonData>,
+{
     /// The organisation ID from which the request originated.
     pub org_id: i64,
 
@@ -936,40 +1110,107 @@ pub struct PluginContext {
     /// such as when the request is made on behalf of Grafana Alerting.
     pub user: Option<User>,
 
-    /// The configured app instance settings.
+    /// The instance settings for the plugin.
     ///
-    /// An app instance is an app plugin of a certain type that has been configured
-    /// and enabled in a Grafana organisation.
-    ///
-    /// This will be `None` if the request does not target an app instance.
-    pub app_instance_settings: Option<AppInstanceSettings>,
+    /// The concrete type of this field will depend on the type of the plugin.
+    /// App plugins will contain [`AppInstanceSettings`], while datasource plugins
+    /// will contain [`DataSourceInstanceSettings`].
+    pub instance_settings: IS,
+    // /// The configured app instance settings.
+    // ///
+    // /// An app instance is an app plugin of a certain type that has been configured
+    // /// and enabled in a Grafana organisation.
+    // ///
+    // /// This will be `None` if the request does not target an app instance.
+    // pub app_instance_settings: Option<AppInstanceSettings<JsonData, SecureJsonData>>,
 
-    /// The configured datasource instance settings.
-    ///
-    /// A datasource instance is a datasource plugin of a certain type that has been configured
-    /// and created in a Grafana organisation. For example, the 'datasource' may be
-    /// the Prometheus datasource plugin, and there may be many configured Prometheus
-    /// datasource instances configured in a Grafana organisation.
-    ///
-    /// This will be `None` if the request does not target a datasource instance.
-    pub datasource_instance_settings: Option<DataSourceInstanceSettings>,
+    // /// The configured datasource instance settings.
+    // ///
+    // /// A datasource instance is a datasource plugin of a certain type that has been configured
+    // /// and created in a Grafana organisation. For example, the 'datasource' may be
+    // /// the Prometheus datasource plugin, and there may be many configured Prometheus
+    // /// datasource instances configured in a Grafana organisation.
+    // ///
+    // /// This will be `None` if the request does not target a datasource instance.
+    // pub datasource_instance_settings: Option<DataSourceInstanceSettings<JsonData, SecureJsonData>>,
+    _json_data: PhantomData<JsonData>,
+    _secure_json_data: PhantomData<SecureJsonData>,
 }
 
-impl TryFrom<pluginv2::PluginContext> for PluginContext {
+impl<IS, JsonData, SecureJsonData> TryFrom<pluginv2::PluginContext>
+    for PluginContext<IS, JsonData, SecureJsonData>
+where
+    JsonData: Debug + DeserializeOwned,
+    SecureJsonData: DeserializeOwned,
+    IS: InstanceSettings<JsonData, SecureJsonData>,
+{
     type Error = ConvertFromError;
     fn try_from(other: pluginv2::PluginContext) -> Result<Self, Self::Error> {
+        let instance_settings = IS::from_proto(
+            other.app_instance_settings,
+            other.data_source_instance_settings,
+            other.plugin_id.clone(),
+        )?;
         Ok(Self {
             org_id: other.org_id,
-            plugin_id: other.plugin_id.clone(),
+            plugin_id: other.plugin_id,
             user: other.user.map(TryInto::try_into).transpose()?,
-            app_instance_settings: other
-                .app_instance_settings
-                .map(TryInto::try_into)
-                .transpose()?,
-            datasource_instance_settings: other
-                .data_source_instance_settings
-                .map(|ds| (ds, other.plugin_id).try_into())
-                .transpose()?,
+            instance_settings,
+            _json_data: PhantomData,
+            _secure_json_data: PhantomData,
         })
     }
+}
+
+/// Marker trait for plugins, used to indicate the type of instance settings they will receive.
+///
+/// Plugin implementations must mark themselves as being a certain type in their
+/// [`ConfiguredPlugin`] implementation (often done using the `GrafanaPlugin` proc-macro).
+pub trait PluginType<JsonData, SecureJsonData>: sealed::Sealed
+where
+    JsonData: Debug + DeserializeOwned,
+    SecureJsonData: DeserializeOwned,
+{
+    /// The type of instance settings that requests to this plugin will receive.
+    type InstanceSettings: InstanceSettings<JsonData, SecureJsonData> + Sync + Send;
+}
+
+/// Marker struct for an app plugin.
+pub struct AppPlugin<JsonData, SecureJsonData> {
+    _json_data: PhantomData<JsonData>,
+    _secure_json_data: PhantomData<SecureJsonData>,
+}
+impl<JsonData, SecureJsonData> PluginType<JsonData, SecureJsonData>
+    for AppPlugin<JsonData, SecureJsonData>
+where
+    JsonData: Debug + DeserializeOwned + Sync + Send,
+    SecureJsonData: DeserializeOwned + Sync + Send,
+{
+    type InstanceSettings = AppInstanceSettings<JsonData, SecureJsonData>;
+}
+impl<JsonData, SecureJsonData> sealed::Sealed for AppPlugin<JsonData, SecureJsonData> {}
+
+/// Marker struct for a datasource plugin.
+pub struct DataSourcePlugin<JsonData, SecureJsonData> {
+    _json_data: PhantomData<JsonData>,
+    _secure_json_data: PhantomData<SecureJsonData>,
+}
+impl<JsonData, SecureJsonData> PluginType<JsonData, SecureJsonData>
+    for DataSourcePlugin<JsonData, SecureJsonData>
+where
+    JsonData: Debug + DeserializeOwned + Sync + Send,
+    SecureJsonData: DeserializeOwned + Sync + Send,
+{
+    type InstanceSettings = DataSourceInstanceSettings<JsonData, SecureJsonData>;
+}
+impl<JsonData, SecureJsonData> sealed::Sealed for DataSourcePlugin<JsonData, SecureJsonData> {}
+
+/// Trait marking the types of a plugin's JSON data and secure JSON data.
+pub trait GrafanaPlugin {
+    /// The type of the plugin
+    type PluginType: PluginType<Self::JsonData, Self::SecureJsonData>;
+    /// The type of the plugin's JSON data.
+    type JsonData: DeserializeOwned + Debug + Send + Sync;
+    /// The type of the plugin's secure JSON data.
+    type SecureJsonData: DeserializeOwned + Send + Sync;
 }

--- a/crates/grafana-plugin-sdk/src/backend/noop.rs
+++ b/crates/grafana-plugin-sdk/src/backend/noop.rs
@@ -26,12 +26,18 @@ impl DataQueryError for Infallible {
     }
 }
 
+impl GrafanaPlugin for NoopService {
+    type PluginType = AppPlugin<Self::JsonData, Self::SecureJsonData>;
+    type JsonData = Value;
+    type SecureJsonData = HashMap<String, String>;
+}
+
 #[tonic::async_trait]
 impl DataService for NoopService {
     type Query = ();
     type QueryError = Infallible;
     type Stream = BoxDataResponseStream<Self::QueryError>;
-    async fn query_data(&self, _request: QueryDataRequest<Self::Query>) -> Self::Stream {
+    async fn query_data(&self, _request: QueryDataRequest<Self::Query, Self>) -> Self::Stream {
         unreachable!()
     }
 }
@@ -41,14 +47,14 @@ impl DiagnosticsService for NoopService {
     type CheckHealthError = Infallible;
     async fn check_health(
         &self,
-        _request: CheckHealthRequest,
+        _request: CheckHealthRequest<Self>,
     ) -> Result<CheckHealthResponse, Self::CheckHealthError> {
         unreachable!()
     }
     type CollectMetricsError = Infallible;
     async fn collect_metrics(
         &self,
-        _request: CollectMetricsRequest,
+        _request: CollectMetricsRequest<Self>,
     ) -> Result<CollectMetricsResponse, Self::CollectMetricsError> {
         unreachable!()
     }
@@ -68,7 +74,7 @@ impl ResourceService for NoopService {
     /// is to use `futures_util::stream::once`.
     async fn call_resource(
         &self,
-        _request: CallResourceRequest,
+        _request: CallResourceRequest<Self>,
     ) -> Result<(Self::InitialResponse, Self::Stream), Self::Error> {
         unreachable!()
     }
@@ -78,19 +84,22 @@ impl ResourceService for NoopService {
 impl StreamService for NoopService {
     async fn subscribe_stream(
         &self,
-        _request: SubscribeStreamRequest,
+        _request: SubscribeStreamRequest<Self>,
     ) -> Result<SubscribeStreamResponse, Self::Error> {
         unreachable!()
     }
     type JsonValue = ();
     type Error = Infallible;
     type Stream = BoxRunStream<Self::Error>;
-    async fn run_stream(&self, _request: RunStreamRequest) -> Result<Self::Stream, Self::Error> {
+    async fn run_stream(
+        &self,
+        _request: RunStreamRequest<Self>,
+    ) -> Result<Self::Stream, Self::Error> {
         unreachable!()
     }
     async fn publish_stream(
         &self,
-        _request: PublishStreamRequest,
+        _request: PublishStreamRequest<Self>,
     ) -> Result<PublishStreamResponse, Self::Error> {
         unreachable!()
     }

--- a/crates/grafana-plugin-sdk/src/backend/stream.rs
+++ b/crates/grafana-plugin-sdk/src/backend/stream.rs
@@ -1,27 +1,34 @@
 //! SDK types and traits relevant to plugins that stream data.
-use std::pin::Pin;
+use std::{fmt, pin::Pin};
 
 use futures_util::{Stream, StreamExt, TryStreamExt};
 use prost::bytes::Bytes;
-use serde::Serialize;
+use serde::{de::DeserializeOwned, Serialize};
 
 use crate::{
-    backend::{ConvertFromError, ConvertToError, PluginContext},
+    backend::{ConvertFromError, ConvertToError, InstanceSettings, PluginContext},
     data,
     live::Path,
     pluginv2,
 };
 
+use super::{GrafanaPlugin, PluginType};
+
 /// A request to subscribe to a stream.
 #[derive(Debug)]
 #[non_exhaustive]
-pub struct SubscribeStreamRequest {
+pub struct InnerSubscribeStreamRequest<IS, JsonData, SecureJsonData>
+where
+    JsonData: fmt::Debug + DeserializeOwned,
+    SecureJsonData: DeserializeOwned,
+    IS: InstanceSettings<JsonData, SecureJsonData>,
+{
     /// Details of the plugin instance from which the request originated.
     ///
     /// If the request originates from a datasource instance, this will
     /// include details about the datasource instance in the
     /// `data_source_instance_settings` field.
-    pub plugin_context: PluginContext,
+    pub plugin_context: PluginContext<IS, JsonData, SecureJsonData>,
 
     /// The subscription channel path that the request wishes to subscribe to.
     pub path: Path,
@@ -34,7 +41,13 @@ pub struct SubscribeStreamRequest {
     pub data: Bytes,
 }
 
-impl TryFrom<pluginv2::SubscribeStreamRequest> for SubscribeStreamRequest {
+impl<IS, JsonData, SecureJsonData> TryFrom<pluginv2::SubscribeStreamRequest>
+    for InnerSubscribeStreamRequest<IS, JsonData, SecureJsonData>
+where
+    JsonData: fmt::Debug + DeserializeOwned,
+    SecureJsonData: DeserializeOwned,
+    IS: InstanceSettings<JsonData, SecureJsonData>,
+{
     type Error = ConvertFromError;
     fn try_from(other: pluginv2::SubscribeStreamRequest) -> Result<Self, Self::Error> {
         Ok(Self {
@@ -47,6 +60,25 @@ impl TryFrom<pluginv2::SubscribeStreamRequest> for SubscribeStreamRequest {
         })
     }
 }
+
+/// A request to 'run' a stream, i.e. begin streaming data.
+///
+/// This is made by Grafana _after_ a stream subscription request has been accepted,
+/// and will include the same `path` as the subscription request.
+///
+/// This is a convenience type alias to hide some of the complexity of
+/// the various generics involved.
+///
+/// The type parameter `T` is the type of the plugin implementation itself,
+/// which must implement [`ConfiguredPlugin`].
+pub type SubscribeStreamRequest<T> = InnerSubscribeStreamRequest<
+    <<T as GrafanaPlugin>::PluginType as PluginType<
+        <T as GrafanaPlugin>::JsonData,
+        <T as GrafanaPlugin>::SecureJsonData,
+    >>::InstanceSettings,
+    <T as GrafanaPlugin>::JsonData,
+    <T as GrafanaPlugin>::SecureJsonData,
+>;
 
 /// The status of a subscribe stream response.
 #[derive(Clone, Copy, Debug)]
@@ -173,9 +205,14 @@ impl From<SubscribeStreamResponse> for pluginv2::SubscribeStreamResponse {
 /// and will include the same `path` as the subscription request.
 #[derive(Debug)]
 #[non_exhaustive]
-pub struct RunStreamRequest {
+pub struct InnerRunStreamRequest<IS, JsonData, SecureJsonData>
+where
+    JsonData: fmt::Debug + DeserializeOwned,
+    SecureJsonData: DeserializeOwned,
+    IS: InstanceSettings<JsonData, SecureJsonData>,
+{
     /// Metadata about the plugin from which the request originated.
-    pub plugin_context: PluginContext,
+    pub plugin_context: PluginContext<IS, JsonData, SecureJsonData>,
 
     /// The subscription path; see module level comments for details.
     pub path: Path,
@@ -188,7 +225,13 @@ pub struct RunStreamRequest {
     pub data: Bytes,
 }
 
-impl TryFrom<pluginv2::RunStreamRequest> for RunStreamRequest {
+impl<IS, JsonData, SecureJsonData> TryFrom<pluginv2::RunStreamRequest>
+    for InnerRunStreamRequest<IS, JsonData, SecureJsonData>
+where
+    JsonData: fmt::Debug + DeserializeOwned,
+    SecureJsonData: DeserializeOwned,
+    IS: InstanceSettings<JsonData, SecureJsonData>,
+{
     type Error = ConvertFromError;
     fn try_from(other: pluginv2::RunStreamRequest) -> Result<Self, Self::Error> {
         Ok(Self {
@@ -201,6 +244,25 @@ impl TryFrom<pluginv2::RunStreamRequest> for RunStreamRequest {
         })
     }
 }
+
+/// A request to 'run' a stream, i.e. begin streaming data.
+///
+/// This is made by Grafana _after_ a stream subscription request has been accepted,
+/// and will include the same `path` as the subscription request.
+///
+/// This is a convenience type alias to hide some of the complexity of
+/// the various generics involved.
+///
+/// The type parameter `T` is the type of the plugin implementation itself,
+/// which must implement [`ConfiguredPlugin`].
+pub type RunStreamRequest<T> = InnerRunStreamRequest<
+    <<T as GrafanaPlugin>::PluginType as PluginType<
+        <T as GrafanaPlugin>::JsonData,
+        <T as GrafanaPlugin>::SecureJsonData,
+    >>::InstanceSettings,
+    <T as GrafanaPlugin>::JsonData,
+    <T as GrafanaPlugin>::SecureJsonData,
+>;
 
 /// A packet of data to be streamed back to the subscribed client.
 ///
@@ -257,20 +319,31 @@ pub type BoxRunStream<E, T = ()> = Pin<Box<dyn Stream<Item = Result<StreamPacket
 
 /// A request to publish data to a stream.
 #[non_exhaustive]
-pub struct PublishStreamRequest {
+pub struct InnerPublishStreamRequest<IS, JsonData, SecureJsonData>
+where
+    JsonData: fmt::Debug + DeserializeOwned,
+    SecureJsonData: DeserializeOwned,
+    IS: InstanceSettings<JsonData, SecureJsonData>,
+{
     /// Details of the plugin instance from which the request originated.
     ///
     /// If the request originates from a datasource instance, this will
     /// include details about the datasource instance in the
     /// `data_source_instance_settings` field.
-    pub plugin_context: PluginContext,
+    pub plugin_context: PluginContext<IS, JsonData, SecureJsonData>,
     /// The subscription path; see module level comments for details.
     pub path: Path,
     /// Data to be published to the stream.
     pub data: serde_json::Value,
 }
 
-impl TryFrom<pluginv2::PublishStreamRequest> for PublishStreamRequest {
+impl<IS, JsonData, SecureJsonData> TryFrom<pluginv2::PublishStreamRequest>
+    for InnerPublishStreamRequest<IS, JsonData, SecureJsonData>
+where
+    JsonData: fmt::Debug + DeserializeOwned,
+    SecureJsonData: DeserializeOwned,
+    IS: InstanceSettings<JsonData, SecureJsonData>,
+{
     type Error = ConvertFromError;
     fn try_from(other: pluginv2::PublishStreamRequest) -> Result<Self, Self::Error> {
         Ok(Self {
@@ -283,6 +356,22 @@ impl TryFrom<pluginv2::PublishStreamRequest> for PublishStreamRequest {
         })
     }
 }
+
+/// A request to publish data to a stream.
+///
+/// This is a convenience type alias to hide some of the complexity of
+/// the various generics involved.
+///
+/// The type parameter `T` is the type of the plugin implementation itself,
+/// which must implement [`ConfiguredPlugin`].
+pub type PublishStreamRequest<T> = InnerPublishStreamRequest<
+    <<T as GrafanaPlugin>::PluginType as PluginType<
+        <T as GrafanaPlugin>::JsonData,
+        <T as GrafanaPlugin>::SecureJsonData,
+    >>::InstanceSettings,
+    <T as GrafanaPlugin>::JsonData,
+    <T as GrafanaPlugin>::SecureJsonData,
+>;
 
 /// The status of a publish stream response.
 #[non_exhaustive]
@@ -380,6 +469,8 @@ impl TryFrom<PublishStreamResponse> for pluginv2::PublishStreamResponse {
 /// use tokio_stream::StreamExt;
 /// use tracing::{debug, info};
 ///
+/// #[derive(Clone, Debug, GrafanaPlugin)]
+/// #[grafana_plugin(plugin_type = "datasource")]
 /// struct MyPlugin;
 ///
 /// #[derive(Debug, Error)]
@@ -411,7 +502,7 @@ impl TryFrom<PublishStreamResponse> for pluginv2::PublishStreamResponse {
 ///     /// and return `NotFound` if not.
 ///     async fn subscribe_stream(
 ///         &self,
-///         request: backend::SubscribeStreamRequest,
+///         request: backend::SubscribeStreamRequest<Self>,
 ///     ) -> Result<backend::SubscribeStreamResponse, Self::Error> {
 ///         let response = if request.path.as_str() == "stream" {
 ///             backend::SubscribeStreamResponse::ok(None)
@@ -430,7 +521,7 @@ impl TryFrom<PublishStreamResponse> for pluginv2::PublishStreamResponse {
 ///     /// This example just creates an in-memory `Frame` in each loop iteration,
 ///     /// sends an updated version of the frame once per second, and updates a loop variable
 ///     /// so that each frame is different.
-///     async fn run_stream(&self, _request: backend::RunStreamRequest) -> Result<Self::Stream, Self::Error> {
+///     async fn run_stream(&self, _request: backend::RunStreamRequest<Self>) -> Result<Self::Stream, Self::Error> {
 ///         info!("Running stream");
 ///         let mut x = 0u32;
 ///         let n = 3;
@@ -454,7 +545,7 @@ impl TryFrom<PublishStreamResponse> for pluginv2::PublishStreamResponse {
 ///     /// Currently unimplemented in this example, but the functionality _should_ work.
 ///     async fn publish_stream(
 ///         &self,
-///         _request: backend::PublishStreamRequest,
+///         _request: backend::PublishStreamRequest<Self>,
 ///     ) -> Result<backend::PublishStreamResponse, Self::Error> {
 ///         info!("Publishing to stream");
 ///         todo!()
@@ -462,7 +553,7 @@ impl TryFrom<PublishStreamResponse> for pluginv2::PublishStreamResponse {
 /// }
 /// ```
 #[tonic::async_trait]
-pub trait StreamService {
+pub trait StreamService: GrafanaPlugin {
     /// Handle requests to begin a subscription to a plugin or datasource managed channel path.
     ///
     ///
@@ -475,7 +566,7 @@ pub trait StreamService {
     /// the [`initial_data`][SubscribeStreamResponse::initial_data].
     async fn subscribe_stream(
         &self,
-        request: SubscribeStreamRequest,
+        request: SubscribeStreamRequest<Self>,
     ) -> Result<SubscribeStreamResponse, Self::Error>;
 
     /// The type of JSON values returned by this stream service.
@@ -508,14 +599,17 @@ pub trait StreamService {
     /// When Grafana detects that there are no longer any subscribers to a channel, the stream
     /// will be terminated until the next active subscriber appears. Stream termination can
     /// may be slightly delayed, generally by a few seconds.
-    async fn run_stream(&self, request: RunStreamRequest) -> Result<Self::Stream, Self::Error>;
+    async fn run_stream(
+        &self,
+        request: RunStreamRequest<Self>,
+    ) -> Result<Self::Stream, Self::Error>;
 
     /// Handle requests to publish to a plugin or datasource managed channel path (currently unimplemented).
     ///
     /// Implementations should check the publish permissions of the incoming request.
     async fn publish_stream(
         &self,
-        request: PublishStreamRequest,
+        request: PublishStreamRequest<Self>,
     ) -> Result<PublishStreamResponse, Self::Error>;
 }
 

--- a/crates/grafana-plugin-sdk/src/backend/stream.rs
+++ b/crates/grafana-plugin-sdk/src/backend/stream.rs
@@ -352,7 +352,7 @@ where
                 .ok_or(ConvertFromError::MissingPluginContext)
                 .and_then(TryInto::try_into)?,
             path: Path::new(other.path)?,
-            data: super::read_json(&other.data)?,
+            data: super::read_json_query(&other.data)?,
         })
     }
 }

--- a/crates/grafana-plugin-sdk/src/lib.rs
+++ b/crates/grafana-plugin-sdk/src/lib.rs
@@ -41,6 +41,9 @@ The following feature flags enable additional functionality for this crate:
 /// error messages.
 pub use arrow2;
 
+#[doc(hidden)]
+pub use serde_json;
+
 #[cfg(feature = "reqwest")]
 extern crate reqwest_lib as reqwest;
 
@@ -56,6 +59,8 @@ pub mod live;
 
 /// Contains useful helper traits for constructing [`Field`][data::Field]s and [`Frame`][data::Frame]s.
 pub mod prelude {
+    pub use grafana_plugin_sdk_macros::GrafanaPlugin;
+
     pub use crate::data::{ArrayIntoField, FromFields, IntoField, IntoFrame, IntoOptField};
 }
 

--- a/crates/grafana-plugin-sdk/src/live/channel.rs
+++ b/crates/grafana-plugin-sdk/src/live/channel.rs
@@ -7,13 +7,14 @@ See the [channel guide] for more information.
 use std::{fmt, str::FromStr};
 
 use itertools::Itertools;
+use serde::Serialize;
 use thiserror::Error;
 
 /// The maximum length of a channel when represented as a string.
 pub const MAX_CHANNEL_LENGTH: usize = 160;
 
 /// The error returned when parsing a channel.
-#[derive(Debug, Error)]
+#[derive(Debug, Error, Serialize)]
 #[non_exhaustive]
 pub enum Error {
     /// The channel was empty.


### PR DESCRIPTION
This PR allows plugins to specify the concrete type of the
JSON/secure JSON data decoded into the `PluginContext.instance_settings`
field on incoming requests. They do so by implementing a new
`GrafanaPlugin` trait (which all plugins must now do); this is made
easier by using an identically named derive macro and specifying the
custom types as attributes.