### PR TITLE
Add 'status' code to 'DataQueryError'; default to Internal Server Error

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 
 - Add `VisType::FlameGraph` variant to indicate that a frame should be visualised using the flame graph panel introduced [here](https://github.com/grafana/grafana/pull/56376).
+- Add overrideable `DataQueryError::status` method which must return a `DataQueryStatus`. This can be used by datasource implementations to provide more detail about how an error should be handled.
 
 ## [0.4.2] - 2022-09-19
 

--- a/crates/grafana-plugin-sdk/examples/main.rs
+++ b/crates/grafana-plugin-sdk/examples/main.rs
@@ -50,6 +50,10 @@ impl backend::DataQueryError for QueryError {
     fn ref_id(self) -> String {
         self.ref_id
     }
+
+    fn status(&self) -> backend::DataQueryStatus {
+        backend::DataQueryStatus::Internal
+    }
 }
 
 #[tonic::async_trait]

--- a/crates/grafana-plugin-sdk/src/backend/data.rs
+++ b/crates/grafana-plugin-sdk/src/backend/data.rs
@@ -142,15 +142,121 @@ pub trait DataQueryError: std::error::Error {
     /// This allows the SDK to align queries up with any failed requests.
     fn ref_id(self) -> String;
 
-    /// A suitable `http::StatusCode` to represent this error.
+    /// A suitable [`DataQueryStatus`] to represent this error.
     ///
     /// This may be used by clients to decide how this error should
     /// be handled. For example, whether the request should be retried,
     /// treated as a client or server error, etc.
     ///
-    /// Defaults to `http::StatusCode::INTERNAL_SERVER_ERROR` if not overridden.
-    fn status(&self) -> http::StatusCode {
-        http::StatusCode::INTERNAL_SERVER_ERROR
+    /// Defaults to [`DataQueryStatus::Unknown`] if not overridden.
+    fn status(&self) -> DataQueryStatus {
+        DataQueryStatus::Unknown
+    }
+}
+
+/// Status codes for [`DataQueryError`].
+///
+/// These generally correspond to HTTP status codes, but are not
+/// a 1:1 mapping: several variants may map to a single HTTP
+/// status code, and not all HTTP status codes are given.
+///
+/// To return a custom HTTP status code in more advanced scenarios,
+/// use [`DataQueryStatus::Custom`] and nest the required
+/// [`http::StatusCode`] inside.
+pub enum DataQueryStatus {
+    /// An error that should be updated to contain an accurate status code,
+    /// as none has been provided.
+    ///
+    /// HTTP status code 500.
+    Unknown,
+
+    /// The query was successful.
+    ///
+    /// HTTP status code 200.
+    OK,
+
+    /// The datasource does not recognize the client's authentication,
+    /// either because it has not been provided
+    /// or is invalid for the operation.
+    ///
+    /// HTTP status code 401.
+    Unauthorized,
+
+    /// The datasource refuses to perform the requested action for the authenticated user.
+    /// HTTP status code 403.
+    Forbidden,
+
+    /// The datasource does not have any corresponding document to return to the request.
+    ///
+    /// HTTP status code 404.
+    NotFound,
+
+    /// The client is rate limited by the datasource and should back-off before trying again.
+    ///
+    /// HTTP status code 429.
+    TooManyRequests,
+
+    /// The datasource was unable to parse the parameters or payload for the request.
+    ///
+    /// HTTP status code 400.
+    BadRequest,
+
+    /// The datasource was able to parse the payload for the request,
+    /// but it failed one or more validation checks.
+    ///
+    /// HTTP status code 400.
+    ValidationFailed,
+
+    /// The datasource acknowledges that there's an error, but that there is
+    /// nothing the client can do to fix it.
+    ///
+    /// HTTP status code 500.
+    Internal,
+
+    /// The datasource does not support the requested action.
+    /// Typically used during development of new features.
+    ///
+    /// HTTP status code 501.
+    NotImplemented,
+
+    /// The datasource did not complete the request within the required time and aborted the action.
+    ///
+    /// HTTP status code 504.
+    Timeout,
+
+    /// The datasource, while acting as a gateway or proxy, received an invalid response
+    /// from the upstream server.
+    ///
+    /// HTTP status code 502.
+    BadGateway,
+
+    /// The datasource encountered another error, best represented by
+    /// the inner status code.
+    Custom(http::StatusCode),
+}
+
+impl DataQueryStatus {
+    fn as_http(&self) -> http::StatusCode {
+        use http::StatusCode;
+        match self {
+            DataQueryStatus::Unknown => StatusCode::INTERNAL_SERVER_ERROR,
+            DataQueryStatus::OK => StatusCode::OK,
+            DataQueryStatus::Unauthorized => StatusCode::UNAUTHORIZED,
+            DataQueryStatus::Forbidden => StatusCode::FORBIDDEN,
+            DataQueryStatus::NotFound => StatusCode::NOT_FOUND,
+            DataQueryStatus::TooManyRequests => StatusCode::TOO_MANY_REQUESTS,
+            DataQueryStatus::BadRequest => StatusCode::BAD_REQUEST,
+            DataQueryStatus::ValidationFailed => StatusCode::BAD_REQUEST,
+            DataQueryStatus::Internal => StatusCode::INTERNAL_SERVER_ERROR,
+            DataQueryStatus::NotImplemented => StatusCode::NOT_IMPLEMENTED,
+            DataQueryStatus::Timeout => StatusCode::GATEWAY_TIMEOUT,
+            DataQueryStatus::BadGateway => StatusCode::BAD_GATEWAY,
+            DataQueryStatus::Custom(inner) => *inner,
+        }
+    }
+
+    fn as_i32(&self) -> i32 {
+        self.as_http().as_u16().into()
     }
 }
 
@@ -311,7 +417,7 @@ where
                             ref_id.clone(),
                             pluginv2::DataResponse {
                                 frames: vec![],
-                                status: http::StatusCode::INTERNAL_SERVER_ERROR.as_u16().into(),
+                                status: DataQueryStatus::Internal.as_i32(),
                                 error: e.to_string(),
                                 json_meta: vec![],
                             },
@@ -322,7 +428,7 @@ where
                             ref_id.clone(),
                             pluginv2::DataResponse {
                                 frames,
-                                status: http::StatusCode::OK.as_u16().into(),
+                                status: DataQueryStatus::OK.as_i32(),
                                 error: "".to_string(),
                                 json_meta: vec![],
                             },
@@ -331,7 +437,7 @@ where
                 )
             }
             Err(e) => {
-                let status = e.status().as_u16().into();
+                let status = e.status().as_i32();
                 let err_string = e.to_string();
                 (
                     e.ref_id(),

--- a/crates/grafana-plugin-sdk/src/backend/mod.rs
+++ b/crates/grafana-plugin-sdk/src/backend/mod.rs
@@ -159,7 +159,8 @@ mod stream;
 mod tracing_fmt;
 
 pub use data::{
-    BoxDataResponseStream, DataQuery, DataQueryError, DataResponse, DataService, QueryDataRequest,
+    BoxDataResponseStream, DataQuery, DataQueryError, DataQueryStatus, DataResponse, DataService,
+    QueryDataRequest,
 };
 pub use diagnostics::{
     CheckHealthRequest, CheckHealthResponse, CollectMetricsRequest, CollectMetricsResponse,

--- a/crates/grafana-plugin-sdk/src/pluginv2/pluginv2.rs
+++ b/crates/grafana-plugin-sdk/src/pluginv2/pluginv2.rs
@@ -155,6 +155,12 @@ pub struct DataResponse {
     /// Warning: Current ignored by frontend. Would be for metadata about the query.
     #[prost(bytes="vec", tag="3")]
     pub json_meta: ::prost::alloc::vec::Vec<u8>,
+    /// When errors exist or a non 2XX status, clients will be passed a 207 HTTP
+    /// error code in /ds/query The status codes should match values from standard
+    /// HTTP status codes If not set explicitly, it will be marshaled to 200 if no
+    /// error exists, or 500 if one does
+    #[prost(int32, tag="4")]
+    pub status: i32,
 }
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct CollectMetricsRequest {

--- a/crates/grafana-plugin-sdk/vendor/proto/backend.proto
+++ b/crates/grafana-plugin-sdk/vendor/proto/backend.proto
@@ -132,6 +132,12 @@ message DataResponse {
   repeated bytes frames = 1;
   string error = 2;
   bytes jsonMeta = 3; // Warning: Current ignored by frontend. Would be for metadata about the query.
+
+  // When errors exist or a non 2XX status, clients will be passed a 207 HTTP
+  // error code in /ds/query The status codes should match values from standard
+  // HTTP status codes If not set explicitly, it will be marshaled to 200 if no
+  // error exists, or 500 if one does
+  int32 status = 4;
 }
 
 //-----------------------------------------------


### PR DESCRIPTION
Example of how https://github.com/grafana/grafana-plugin-sdk-go/pull/544 may
look in this SDK.
