### PR TITLE
Use GATs in `DataService`

### DIFF
--- a/crates/grafana-plugin-sdk/src/backend/data.rs
+++ b/crates/grafana-plugin-sdk/src/backend/data.rs
@@ -254,9 +254,9 @@ pub trait DataService {
     ///
     /// The request will contain zero or more queries, as well as information about the
     /// origin of the queries (such as the datasource instance) in the `plugin_context` field.
-    async fn query_data<'st, 'r: 'st, 's: 'r>(
+    async fn query_data<'st, 's: 'st>(
         &'s self,
-        request: &'r QueryDataRequest<Self::Query>,
+        request: QueryDataRequest<Self::Query>,
     ) -> Self::Stream<'st>;
 }
 
@@ -290,7 +290,7 @@ where
     ) -> Result<tonic::Response<pluginv2::QueryDataResponse>, tonic::Status> {
         let responses = DataService::query_data(
             self,
-            &request
+            request
                 .into_inner()
                 .try_into()
                 .map_err(ConvertFromError::into_tonic_status)?,

--- a/crates/grafana-plugin-sdk/src/backend/mod.rs
+++ b/crates/grafana-plugin-sdk/src/backend/mod.rs
@@ -74,7 +74,7 @@ impl backend::DataService for MyPlugin {
     ///
     /// In general the concrete type will be impossible to name in advance,
     /// so the `backend::BoxDataResponseStream` type alias will be useful.
-    type Stream = backend::BoxDataResponseStream<Self::QueryError>;
+    type Stream<'a> = backend::BoxDataResponseStream<'a, Self::QueryError>;
 
     /// Respond to a request for data from Grafana.
     ///
@@ -279,7 +279,7 @@ impl ShutdownHandler {
 ///     ///
 ///     /// In general the concrete type will be impossible to name in advance,
 ///     /// so the `backend::BoxDataResponseStream` type alias will be useful.
-///     type Stream = backend::BoxDataResponseStream<Self::QueryError>;
+///     type Stream<'a> = backend::BoxDataResponseStream<'a, Self::QueryError>;
 ///
 ///     /// Respond to a request for data from Grafana.
 ///     ///

--- a/crates/grafana-plugin-sdk/src/backend/noop.rs
+++ b/crates/grafana-plugin-sdk/src/backend/noop.rs
@@ -31,9 +31,9 @@ impl DataService for NoopService {
     type Query = ();
     type QueryError = Infallible;
     type Stream<'a> = BoxDataResponseStream<'static, Self::QueryError>;
-    async fn query_data<'st, 'r: 'st, 's: 'r>(
+    async fn query_data<'st, 's: 'st>(
         &'s self,
-        _request: &'r QueryDataRequest<Self::Query>,
+        _request: QueryDataRequest<Self::Query>,
     ) -> Self::Stream<'st> {
         unreachable!()
     }

--- a/crates/grafana-plugin-sdk/src/backend/noop.rs
+++ b/crates/grafana-plugin-sdk/src/backend/noop.rs
@@ -30,8 +30,11 @@ impl DataQueryError for Infallible {
 impl DataService for NoopService {
     type Query = ();
     type QueryError = Infallible;
-    type Stream = BoxDataResponseStream<Self::QueryError>;
-    async fn query_data(&self, _request: QueryDataRequest<Self::Query>) -> Self::Stream {
+    type Stream<'a> = BoxDataResponseStream<'static, Self::QueryError>;
+    async fn query_data<'st, 'r: 'st, 's: 'r>(
+        &'s self,
+        _request: &'r QueryDataRequest<Self::Query>,
+    ) -> Self::Stream<'st> {
         unreachable!()
     }
 }


### PR DESCRIPTION
This makes the `DataService::Stream` associated type generic over a lifetime bound by `Self`. This means users can borrow data from `self` in their implementations even if they reference it in the futures of their stream. TBC whether this is actually worth doing 🤷 