### PR TITLE
Fix use of deprecated chrono functions

### DIFF
--- a/crates/grafana-plugin-sdk/build.rs
+++ b/crates/grafana-plugin-sdk/build.rs
@@ -2,7 +2,7 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
     #[cfg(feature = "gen-proto")]
     {
         let mut config = prost_build::Config::new();
-        config.bytes(&[
+        config.bytes([
             ".pluginv2.CallResourceRequest",
             ".pluginv2.CallResourceResponse",
             ".pluginv2.RunStreamRequest",

--- a/crates/grafana-plugin-sdk/src/data/field_type.rs
+++ b/crates/grafana-plugin-sdk/src/data/field_type.rs
@@ -153,6 +153,9 @@ where
     }
 }
 
+// The `Date` type was only recently deprecated, we should remove support for it in the next
+// minor version.
+#[allow(deprecated)]
 impl<T> FieldType for Date<T>
 where
     T: Offset + TimeZone,
@@ -166,6 +169,9 @@ where
     }
 }
 
+// The `Date` type was only recently deprecated, we should remove support for it in the next
+// minor version.
+#[allow(deprecated)]
 impl<T> IntoFieldType for Date<T>
 where
     T: Offset + TimeZone,
@@ -173,7 +179,11 @@ where
     type ElementType = i64;
     const TYPE_INFO_TYPE: TypeInfoType = TypeInfoType::Time;
     fn into_field_type(self) -> Option<Self::ElementType> {
-        Some(self.and_hms(0, 0, 0).timestamp_nanos())
+        Some(
+            self.and_hms_opt(0, 0, 0)
+                .expect("hms are valid")
+                .timestamp_nanos(),
+        )
     }
 }
 
@@ -191,7 +201,11 @@ impl IntoFieldType for NaiveDate {
     type ElementType = i64;
     const TYPE_INFO_TYPE: TypeInfoType = TypeInfoType::Time;
     fn into_field_type(self) -> Option<Self::ElementType> {
-        Some(self.and_hms(0, 0, 0).timestamp_nanos())
+        Some(
+            self.and_hms_opt(0, 0, 0)
+                .expect("hms are valid")
+                .timestamp_nanos(),
+        )
     }
 }
 


### PR DESCRIPTION
Also add a comment to allow our use of chrono::Date for now; this impl
should be removed in the next minor version.
