### PR TITLE
Remove Option wrapper from PluginContext on all request types

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
+- Change the `plugin_context` field of various structs to be non-optional, matching the Go SDK.
 - Bump arrow2 dependency to 0.15.0
 
 ## [0.4.2] - 2022-09-19

--- a/crates/grafana-plugin-sdk/src/backend/diagnostics.rs
+++ b/crates/grafana-plugin-sdk/src/backend/diagnostics.rs
@@ -36,7 +36,7 @@ impl From<HealthStatus> for pluginv2::check_health_response::HealthStatus {
 #[non_exhaustive]
 pub struct CheckHealthRequest {
     /// Details of the plugin instance from which the request originated.
-    pub plugin_context: Option<PluginContext>,
+    pub plugin_context: PluginContext,
     /// Headers included along with the request by Grafana.
     pub headers: HashMap<String, String>,
 }
@@ -45,7 +45,10 @@ impl TryFrom<pluginv2::CheckHealthRequest> for CheckHealthRequest {
     type Error = ConvertFromError;
     fn try_from(other: pluginv2::CheckHealthRequest) -> Result<Self, Self::Error> {
         Ok(Self {
-            plugin_context: other.plugin_context.map(TryInto::try_into).transpose()?,
+            plugin_context: other
+                .plugin_context
+                .ok_or(ConvertFromError::MissingPluginContext)
+                .and_then(TryInto::try_into)?,
             headers: other.headers,
         })
     }
@@ -145,14 +148,17 @@ impl From<CheckHealthResponse> for pluginv2::CheckHealthResponse {
 #[non_exhaustive]
 pub struct CollectMetricsRequest {
     /// Details of the plugin instance from which the request originated.
-    pub plugin_context: Option<PluginContext>,
+    pub plugin_context: PluginContext,
 }
 
 impl TryFrom<pluginv2::CollectMetricsRequest> for CollectMetricsRequest {
     type Error = ConvertFromError;
     fn try_from(other: pluginv2::CollectMetricsRequest) -> Result<Self, Self::Error> {
         Ok(Self {
-            plugin_context: other.plugin_context.map(TryInto::try_into).transpose()?,
+            plugin_context: other
+                .plugin_context
+                .ok_or(ConvertFromError::MissingPluginContext)
+                .and_then(TryInto::try_into)?,
         })
     }
 }

--- a/crates/grafana-plugin-sdk/src/pluginv2/pluginv2.rs
+++ b/crates/grafana-plugin-sdk/src/pluginv2/pluginv2.rs
@@ -181,7 +181,7 @@ pub struct DataResponse {
     /// error code in /ds/query The status codes should match values from standard
     /// HTTP status codes If not set explicitly, it will be marshaled to 200 if no
     /// error exists, or 500 if one does
-    #[prost(int32, tag="4")]
+    #[prost(int32, tag = "4")]
     pub status: i32,
 }
 #[allow(clippy::derive_partial_eq_without_eq)]


### PR DESCRIPTION
It's non-optional in the Go SDK, I think it was just the
optional-by-default nature of proto3 that made me think
it should be optional in these requests. This should simplify user code
since users no longer need to check for the presence of the context.
