### PR TITLE
Add arrow-array support for Field

### DIFF
--- a/crates/grafana-plugin-sdk/Cargo.toml
+++ b/crates/grafana-plugin-sdk/Cargo.toml
@@ -9,6 +9,8 @@ repository = "https://github.com/grafana/grafana-plugin-sdk-rust"
 description = "SDK for building Grafana backend plugins."
 
 [dependencies]
+arrow-array = { version = ">=40", optional = true } # synced with arrow2
+arrow-schema = { version = ">=40", optional = true } # synced with arrow2
 arrow2 = { version = "0.18.0", features = ["io_ipc"] }
 cfg-if = "1.0.0"
 chrono = "0.4.26"
@@ -61,6 +63,7 @@ all-features = true
 rustdoc-args = ["--cfg", "docsrs"]
 
 [features]
+arrow = ["dep:arrow-array", "dep:arrow-schema", "arrow2/arrow"]
 reqwest = ["reqwest_lib"]
 # Since prost 0.11 we no longer use prost-build at build time to generate code,
 # because it requires protoc. The generated code is instead checked in to source

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,3 +1,3 @@
 [toolchain]
-channel = "1.57.0"
+channel = "1.62.0"
 components = ["rustfmt", "clippy"]


### PR DESCRIPTION
This PR allows the `&dyn Array` of `arrow-array` to be converted to Grafana's `Field` structure as easily as the `Array trait` of `arrow2`.

```rust
// AS-IS (unchanged)
let array = ::arrow2::array::PrimitiveArray::from_vec(vec![1, 2, 3]);  // Int32Array -> ::arrow2::Array trait
let field = ::grafana_plugin_sdk::data::ArrayIntoField::try_into_field(array, "field")?;

// TO-BE (added)
let array = Arc::new(::arrow_array::array::PrimitiveArray::from_vec(vec![1, 2, 3]));  // Int32Array -> Arc<dyn ::arrow_array::Array>
let field = ::grafana_plugin_sdk::data::ArrayRefIntoField::try_into_field(&array, "field")?;
```

Thanks to the interoperability of `arrow-array` and `arrow2`, the implementation of `arrow2` closely matches that of `arrow-array` and is easily convertible.

However, unnecessary duplication of code occurred, and I think this can be solved by defining a macro. If you think this is necessary, I will pursue it.