### PR TITLE
chore: update vendored proto file

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased] - ReleaseDate
 
+### Added
+
+- Add `AppInstanceSettings::api_version` and `DataSourceInstanceSettings::api_version` fields.
+
+### Changed
+
+- Update the vendored protobuf definitions to match version 0.249.0 of the Go SDK.
+  This has also added a new field, `api_version`, to the `AppInstanceSettings` and
+  `DataSourceInstanceSettings` structs.
+
 ## [0.5.0] - 2024-09-17
 
 ### Added

--- a/crates/grafana-plugin-sdk/Cargo.toml
+++ b/crates/grafana-plugin-sdk/Cargo.toml
@@ -4,7 +4,7 @@ version = "0.5.0"
 authors = ["Ben Sully <ben.sully@grafana.com>"]
 license = "MIT/Apache-2.0"
 edition = "2021"
-rust-version = "1.63"
+rust-version = "1.77"
 repository = "https://github.com/grafana/grafana-plugin-sdk-rust"
 description = "SDK for building Grafana backend plugins."
 

--- a/crates/grafana-plugin-sdk/src/backend/error_source.rs
+++ b/crates/grafana-plugin-sdk/src/backend/error_source.rs
@@ -1,0 +1,23 @@
+use std::fmt;
+
+/// The source of an error.
+///
+/// This is used to indicate whether the error occurred in the plugin or downstream.
+#[derive(Debug, Default, Clone, Copy, PartialEq, Eq, Hash)]
+#[non_exhaustive]
+pub enum ErrorSource {
+    /// The error occurred in the plugin.
+    #[default]
+    Plugin,
+    /// The error occurred downstream of the plugin.
+    Downstream,
+}
+
+impl fmt::Display for ErrorSource {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            Self::Plugin => f.write_str("plugin"),
+            Self::Downstream => f.write_str("downstream"),
+        }
+    }
+}

--- a/crates/grafana-plugin-sdk/src/backend/mod.rs
+++ b/crates/grafana-plugin-sdk/src/backend/mod.rs
@@ -157,6 +157,7 @@ pub use tonic::async_trait;
 
 mod data;
 mod diagnostics;
+mod error_source;
 mod noop;
 mod resource;
 mod stream;
@@ -170,6 +171,7 @@ pub use diagnostics::{
     CheckHealthRequest, CheckHealthResponse, CollectMetricsRequest, CollectMetricsResponse,
     DiagnosticsService, HealthStatus, Payload as MetricsPayload,
 };
+pub use error_source::ErrorSource;
 pub use resource::{
     BoxResourceFuture, BoxResourceStream, CallResourceRequest, ErrIntoHttpResponse,
     IntoHttpResponse, ResourceService,
@@ -879,6 +881,10 @@ pub struct AppInstanceSettings<JsonData, SecureJsonData> {
     pub decrypted_secure_json_data: SecureJsonData,
     /// The last time the configuration for the app plugin instance was updated.
     pub updated: DateTime<Utc>,
+
+    /// The API version when the settings were saved.
+    /// NOTE: this may be an older version than the current apiVersion.
+    pub api_version: String,
 }
 
 impl<JsonData, SecureJsonData> Debug for AppInstanceSettings<JsonData, SecureJsonData>
@@ -890,6 +896,7 @@ where
             .field("json_data", &self.json_data)
             .field("decrypted_secure_json_data", &"<redacted>")
             .field("updated", &self.updated)
+            .field("api_version", &self.api_version)
             .finish()
     }
 }
@@ -918,6 +925,7 @@ where
                         .ok_or(ConvertFromError::InvalidTimestamp {
                             timestamp: proto.last_updated_ms,
                         })?,
+                    api_version: proto.api_version,
                 })
             })
             .transpose()
@@ -988,6 +996,10 @@ pub struct DataSourceInstanceSettings<JsonData, SecureJsonData> {
 
     /// The last time the configuration for the datasource instance was updated.
     pub updated: DateTime<Utc>,
+
+    /// The API version when the settings were saved.
+    /// NOTE: this may be an older version than the current apiVersion.
+    pub api_version: String,
 }
 
 impl<JsonData, SecureJsonData> Debug for DataSourceInstanceSettings<JsonData, SecureJsonData>
@@ -1008,6 +1020,7 @@ where
             .field("json_data", &self.json_data)
             .field("decrypted_secure_json_data", &"<redacted>")
             .field("updated", &self.updated)
+            .field("api_version", &self.api_version)
             .finish()
     }
 }
@@ -1045,6 +1058,7 @@ where
                         .ok_or(ConvertFromError::InvalidTimestamp {
                             timestamp: proto.last_updated_ms,
                         })?,
+                    api_version: proto.api_version,
                 })
             })
             .transpose()

--- a/crates/grafana-plugin-sdk/vendor/proto/backend.proto
+++ b/crates/grafana-plugin-sdk/vendor/proto/backend.proto
@@ -11,9 +11,14 @@ message AppInstanceSettings {
   bytes jsonData = 3;
   map<string,string> decryptedSecureJsonData = 4;
   int64 lastUpdatedMS = 5;
+
+  // The API version when the settings were saved
+  // NOTE: this may be an older version than the current apiVersion
+  string apiVersion = 6;
 }
 
 message DataSourceInstanceSettings {
+  // Deprecatd: Internal ID, do not use this for anythign important
   int64 id = 1;
   string name = 2;
   string url = 3;
@@ -23,8 +28,16 @@ message DataSourceInstanceSettings {
   string basicAuthUser = 7;
   bytes jsonData = 8;
   map<string,string> decryptedSecureJsonData = 9;
+
+  // timestamp when the settings where last changed
   int64 lastUpdatedMS = 10;
+
+  // Datasoruce unique ID (within an org/stack namespace)
   string uid = 11;
+
+  // The API version when the settings were saved.
+  // NOTE: this may be an older version than the current apiVersion
+  string apiVersion = 12;
 }
 
 message User {
@@ -35,13 +48,13 @@ message User {
 }
 
 message PluginContext {
-  // The Grafana organization id the request originating from.
+  // The Grafana organization id the request originates from.
   int64 orgId = 1;
 
-  // The unique identifier of the plugin the request  originating from.
+  // The unique identifier of the plugin the request is targeted for.
   string pluginId = 2;
 
-  // The Grafana user the request originating from.
+  // The Grafana user the request originates from.
   //
   // Will not be provided if Grafana backend initiated the request.
   User user = 3;
@@ -59,6 +72,18 @@ message PluginContext {
   //
   // Will only be set if request targeting a data source instance.
   DataSourceInstanceSettings dataSourceInstanceSettings = 5;
+
+  // The grafana configuration as a map of key/value pairs.
+  map<string,string> grafanaConfig = 6;
+
+  // The version of the plugin the request is targeted for.
+  string pluginVersion = 7;
+
+  // The user agent of the Grafana server that initiated the gRPC request.
+  string userAgent = 8;
+
+  // The API version that initiated a request
+  string apiVersion = 9;
 }
 
 //---------------------------------------------------------
@@ -83,8 +108,13 @@ message CallResourceRequest {
 }
 
 message CallResourceResponse {
+  // Maps to raw HTTP status codes when passed over HTTP
   int32 code = 1;
+
+  // Raw HTTP headers sent to the client
   map<string,StringList> headers = 2;
+
+  // Raw HTTP body bytes sent to the client
   bytes body = 3;
 }
 
@@ -130,14 +160,20 @@ message DataResponse {
   // Arrow encoded DataFrames
   // Frame has its own meta, warnings, and repeats refId
   repeated bytes frames = 1;
-  string error = 2;
-  bytes jsonMeta = 3; // Warning: Current ignored by frontend. Would be for metadata about the query.
 
-  // When errors exist or a non 2XX status, clients will be passed a 207 HTTP
-  // error code in /ds/query The status codes should match values from standard
-  // HTTP status codes If not set explicitly, it will be marshaled to 200 if no
-  // error exists, or 500 if one does
+  // Error message
+  string error = 2;
+
+  // Currently not used and not exposed in the frontend
+  bytes jsonMeta = 3;
+
+  // When errors exist or a non 2XX status, clients will be passed a 207 HTTP error code in /ds/query
+  // The status codes should match values from standard HTTP status codes
+  // If not set explicitly, it will be marshaled to 200 if no error exists, or 500 if one does
   int32 status = 4;
+
+  // Error source
+  string errorSource = 5;
 }
 
 //-----------------------------------------------
@@ -181,7 +217,7 @@ message CheckHealthResponse {
 }
 
 //-----------------------------------------------------------------
-// Stream -- EXPERIMENTAL and is subject to change until 8.0
+// Stream
 //-----------------------------------------------------------------
 
 service Stream {
@@ -269,4 +305,174 @@ message RunStreamRequest {
 message StreamPacket {
   // JSON-encoded data to publish into a channel.
   bytes data = 1;
+}
+
+//-----------------------------------------------------------------
+// AdmissionControl -- EXPERIMENTAL and is subject to change until 12.??
+//-----------------------------------------------------------------
+
+// Admission control is a service based on the kubernetes admission webhook patterns.
+// This service can be used to verify if objects are valid and convert between versions
+// See: https://github.com/kubernetes/kubernetes/blob/v1.30.0/pkg/apis/admission/types.go#L41
+// And: https://github.com/grafana/grafana-app-sdk/blob/main/resource/admission.go#L14
+service AdmissionControl {
+  // Validate a resource -- the response is a simple yes/no
+  rpc ValidateAdmission(AdmissionRequest) returns (ValidationResponse);
+
+  // Return a modified copy of the request that can be saved or a descriptive error
+  rpc MutateAdmission(AdmissionRequest) returns (MutationResponse);
+}
+
+// Identify the Object properties
+message GroupVersionKind {
+  string group = 1;
+  string version = 2;
+  string kind = 3;
+}
+
+// AdmissionRequest contains information from a kubernetes Admission request and decoded object(s).
+message AdmissionRequest {
+  // Operation is the type of resource operation being checked for admission control
+  // https://github.com/kubernetes/kubernetes/blob/v1.30.0/pkg/apis/admission/types.go#L158
+  enum Operation {
+    CREATE = 0;
+    UPDATE = 1;
+    DELETE = 2;
+  }
+
+  // NOTE: this may not include app or datasource instance settings depending on the request
+  PluginContext pluginContext = 1;
+
+  // The requested operation
+  Operation operation = 2;
+  
+  // The object kind
+  GroupVersionKind kind = 3;
+
+  // Object is the object in the request.  This includes the full metadata envelope.
+  bytes object_bytes = 4;
+
+  // OldObject is the object as it currently exists in storage. This includes the full metadata envelope.
+  bytes old_object_bytes = 5;
+}
+
+
+// Check if an object can be admitted
+message ValidationResponse {
+  // Allowed indicates whether or not the admission request was permitted.
+  bool allowed = 1;
+
+  // Result contains extra details into why an admission request was denied.
+  // This field IS NOT consulted in any way if "Allowed" is "true".
+  // +optional
+  StatusResult result = 2;
+
+  // warnings is a list of warning messages to return to the requesting API client.
+  // Warning messages describe a problem the client making the API request should correct or be aware of.
+  // Limit warnings to 120 characters if possible.
+  // Warnings over 256 characters and large numbers of warnings may be truncated.
+  // +optional
+  repeated string warnings = 3;
+}
+
+// Return a mutated copy of the object in a form that can be admitted
+message MutationResponse {
+  // Allowed indicates whether or not the admission request was permitted.
+  bool allowed = 1;
+
+  // Result contains extra details into why an admission request was denied.
+  // This field IS NOT consulted in any way if "Allowed" is "true".
+  // +optional
+  StatusResult result = 2;
+
+  // warnings is a list of warning messages to return to the requesting API client.
+  // Warning messages describe a problem the client making the API request should correct or be aware of.
+  // Limit warnings to 120 characters if possible.
+  // Warnings over 256 characters and large numbers of warnings may be truncated.
+  // +optional
+  repeated string warnings = 3;
+
+  // Mutated object bytes
+  bytes object_bytes = 4;
+}
+
+//-----------------------------------------------------------------
+// ResourceConversion -- EXPERIMENTAL and is subject to change until 12.??
+//-----------------------------------------------------------------
+
+// ResourceConversion is a service that can be used to convert resources between versions
+// See: https://kubernetes.io/docs/tasks/extend-kubernetes/custom-resources/custom-resource-definition-versioning/#webhook-request-and-response
+service ResourceConversion {
+  // Convert objects to a target version
+  rpc ConvertObjects(ConversionRequest) returns (ConversionResponse);
+}
+
+// GroupVersion represents the API group and version of a resource.
+message GroupVersion{
+  string group = 1;
+  string version = 2;
+}
+
+// RawObject contains a resource serialized into a byte array with a content type
+message RawObject {
+  // Raw is the serialized object
+  bytes raw = 1;
+  // ContentType is the media type of the raw object
+  string content_type = 2;
+}
+
+// ConversionRequest supports converting objects from one version to another 
+message ConversionRequest {
+  // NOTE: this may not include app or datasource instance settings depending on the request
+  PluginContext pluginContext = 1;
+
+  // uid is an identifier for the individual request/response. It allows distinguishing instances of requests which are
+  // otherwise identical (parallel requests, etc).
+  // The UID is meant to track the round trip (request/response) between the Kubernetes API server and the webhook, not the user request.
+  // It is suitable for correlating log entries between the webhook and apiserver, for either auditing or debugging.
+  string uid = 2;
+
+  // Objects to convert
+  // +listType=atomic
+  repeated RawObject objects = 3;
+
+  // Target converted version
+  GroupVersion target_version = 4;
+}
+
+
+// ConversionResponse contains the converted objects
+message ConversionResponse {
+  // uid is an identifier for the individual request/response.
+  // This should be copied over from the corresponding `request.uid`.
+  string uid = 1;
+
+  // result contains extra details into why an admission request was denied.
+  StatusResult result = 2;
+
+  // objects is the list of converted version of `request.objects` if the `result` is successful, otherwise empty.
+  // +listType=atomic
+  repeated RawObject objects = 3;
+}
+
+// Status structure is copied from:
+// https://github.com/kubernetes/apimachinery/blob/v0.30.1/pkg/apis/meta/v1/generated.proto#L979
+message StatusResult {
+  // Status of the operation.
+  // One of: "Success" or "Failure".
+  // More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#spec-and-status
+  // +optional
+  string status = 1;
+  // A human-readable description of the status of this operation.
+  // +optional
+  string message = 2;
+  // A machine-readable description of why this operation is in the
+  // "Failure" status. If this value is empty there
+  // is no information available. A Reason clarifies an HTTP status
+  // code but does not override it.
+  // +optional
+  string reason = 3;
+  // Suggested HTTP return code for this status, 0 if not set.
+  // +optional
+  int32 code = 4;
 }


### PR DESCRIPTION
This commit updates the vendored proto file to that found in version 0.249.0 of the Go SDK, and adds a couple of extra fields:

- `api_version`, on app and datasource instance settings
- `error_source`, on a data response. This can be customimsed by overriding the new `DataQueryError::source` method.