### PR TITLE
chore: fix broken docs

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -89,3 +89,24 @@ jobs:
         with:
           command: clippy
           args: -- -D warnings
+  doc:
+    name: Doc
+    env:
+      RUSTDOCFLAGS: -D warnings
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout sources
+        uses: actions/checkout@v3
+
+      - name: Install stable toolchain
+        uses: actions-rs/toolchain@v1
+        with:
+          profile: minimal
+          toolchain: stable
+          override: true
+
+      - name: Run cargo doc
+        uses: actions-rs/cargo@v1
+        with:
+          command: doc
+          args: --no-deps --features reqwest --document-private-items

--- a/.github/workflows/rustdoc.yml
+++ b/.github/workflows/rustdoc.yml
@@ -7,7 +7,7 @@ on:
 env:
   CARGO_INCREMENTAL: 0
   CARGO_NET_RETRY: 10
-  RUSTFLAGS: "-D warnings -W unreachable-pub"
+  RUSTDOCFLAGS: "-D warnings -W unreachable-pub --cfg docsrs"
   RUSTUP_MAX_RETRIES: 10
 
 jobs:
@@ -27,7 +27,7 @@ jobs:
         components: rustfmt, rust-src
 
     - name: Build Documentation
-      run: RUSTDOCFLAGS="--cfg docsrs" cargo doc --no-deps --features reqwest
+      run: cargo doc --no-deps --features reqwest
 
     - name: Deploy Docs
       uses: peaceiris/actions-gh-pages@v3.7.3

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Update the vendored protobuf definitions to match version 0.249.0 of the Go SDK.
   This has also added a new field, `api_version`, to the `AppInstanceSettings` and
   `DataSourceInstanceSettings` structs.
+- The `ArrayRefIntoField` trait is now correctly hidden behind the `arrow` feature flag.
 
 ## [0.5.0] - 2024-09-17
 

--- a/crates/grafana-plugin-sdk/src/backend/data.rs
+++ b/crates/grafana-plugin-sdk/src/backend/data.rs
@@ -79,7 +79,7 @@ where
 /// `Self::Query` here.
 ///
 /// The type parameter `T` is the type of the plugin implementation itself,
-/// which must implement [`ConfiguredPlugin`].
+/// which must implement [`GrafanaPlugin`].
 pub type QueryDataRequest<Q, T> = InnerQueryDataRequest<
     Q,
     <<T as GrafanaPlugin>::PluginType as PluginType<

--- a/crates/grafana-plugin-sdk/src/backend/diagnostics.rs
+++ b/crates/grafana-plugin-sdk/src/backend/diagnostics.rs
@@ -76,7 +76,7 @@ where
 /// the various generics involved.
 ///
 /// The type parameter `T` is the type of the plugin implementation itself,
-/// which must implement `ConfiguredPlugin`.
+/// which must implement `GrafanaPlugin`.
 pub type CheckHealthRequest<T> = InnerCheckHealthRequest<
     <<T as GrafanaPlugin>::PluginType as PluginType<
         <T as GrafanaPlugin>::JsonData,
@@ -212,7 +212,7 @@ where
 /// the various generics involved.
 ///
 /// The type parameter `T` is the type of the plugin implementation itself,
-/// which must implement `ConfiguredPlugin`.
+/// which must implement `GrafanaPlugin`.
 pub type CollectMetricsRequest<T> = InnerCollectMetricsRequest<
     <<T as GrafanaPlugin>::PluginType as PluginType<
         <T as GrafanaPlugin>::JsonData,

--- a/crates/grafana-plugin-sdk/src/backend/mod.rs
+++ b/crates/grafana-plugin-sdk/src/backend/mod.rs
@@ -1139,7 +1139,7 @@ where
 /// Marker trait for plugins, used to indicate the type of instance settings they will receive.
 ///
 /// Plugin implementations must mark themselves as being a certain type in their
-/// [`ConfiguredPlugin`] implementation (often done using the `GrafanaPlugin` proc-macro).
+/// [`GrafanaPlugin`] implementation (often done using the `GrafanaPlugin` proc-macro).
 pub trait PluginType<JsonData, SecureJsonData>: sealed::Sealed
 where
     JsonData: Debug + DeserializeOwned,

--- a/crates/grafana-plugin-sdk/src/backend/resource.rs
+++ b/crates/grafana-plugin-sdk/src/backend/resource.rs
@@ -119,7 +119,7 @@ impl TryFrom<Response<Bytes>> for pluginv2::CallResourceResponse {
 /// the various generics involved.
 ///
 /// The type parameter `T` is the type of the plugin implementation itself,
-/// which must implement [`ConfiguredPlugin`].
+/// which must implement [`GrafanaPlugin`].
 pub type CallResourceRequest<T> = InnerCallResourceRequest<
     <<T as GrafanaPlugin>::PluginType as PluginType<
         <T as GrafanaPlugin>::JsonData,

--- a/crates/grafana-plugin-sdk/src/backend/stream.rs
+++ b/crates/grafana-plugin-sdk/src/backend/stream.rs
@@ -70,7 +70,7 @@ where
 /// the various generics involved.
 ///
 /// The type parameter `T` is the type of the plugin implementation itself,
-/// which must implement [`ConfiguredPlugin`].
+/// which must implement [`GrafanaPlugin`].
 pub type SubscribeStreamRequest<T> = InnerSubscribeStreamRequest<
     <<T as GrafanaPlugin>::PluginType as PluginType<
         <T as GrafanaPlugin>::JsonData,
@@ -254,7 +254,7 @@ where
 /// the various generics involved.
 ///
 /// The type parameter `T` is the type of the plugin implementation itself,
-/// which must implement [`ConfiguredPlugin`].
+/// which must implement [`GrafanaPlugin`].
 pub type RunStreamRequest<T> = InnerRunStreamRequest<
     <<T as GrafanaPlugin>::PluginType as PluginType<
         <T as GrafanaPlugin>::JsonData,
@@ -363,7 +363,7 @@ where
 /// the various generics involved.
 ///
 /// The type parameter `T` is the type of the plugin implementation itself,
-/// which must implement [`ConfiguredPlugin`].
+/// which must implement [`GrafanaPlugin`].
 pub type PublishStreamRequest<T> = InnerPublishStreamRequest<
     <<T as GrafanaPlugin>::PluginType as PluginType<
         <T as GrafanaPlugin>::JsonData,

--- a/crates/grafana-plugin-sdk/src/data/field.rs
+++ b/crates/grafana-plugin-sdk/src/data/field.rs
@@ -371,7 +371,7 @@ where
     }
 }
 
-/// Helper trait for creating a [`Field`] from an [`Array`][arrow2::array::Array].
+/// Helper trait for creating a [`Field`] from an [`Array`].
 pub trait ArrayIntoField {
     /// Create a `Field` using `self` as the values.
     ///

--- a/crates/grafana-plugin-sdk/src/data/field.rs
+++ b/crates/grafana-plugin-sdk/src/data/field.rs
@@ -400,6 +400,7 @@ where
 }
 
 /// Helper trait for creating a [`Field`] from an [`Array`][arrow_array::Array].
+#[cfg(feature = "arrow")]
 pub trait ArrayRefIntoField {
     /// Create a `Field` using `self` as the values.
     ///

--- a/crates/grafana-plugin-sdk/src/data/frame/to_arrow.rs
+++ b/crates/grafana-plugin-sdk/src/data/frame/to_arrow.rs
@@ -6,7 +6,7 @@ use thiserror::Error;
 
 use crate::data::{field::Field, frame::CheckedFrame};
 
-/// Errors occurring when serializing a [`Frame`] to the Arrow IPC format.
+/// Errors occurring when serializing a [`Frame`][crate::data::Frame] to the Arrow IPC format.
 #[derive(Debug, Error)]
 #[non_exhaustive]
 pub enum Error {
@@ -54,7 +54,7 @@ impl CheckedFrame<'_> {
         Ok(Schema::from(fields).with_metadata(metadata))
     }
 
-    /// Convert this [`Frame`] to Arrow using the IPC format.
+    /// Convert this [`Frame`][crate::data::Frame] to Arrow using the IPC format.
     ///
     /// If `ref_id` is provided, it is passed down to the various conversion
     /// function and takes precedence over the `ref_id` set on the frame.

--- a/crates/grafana-plugin-sdk/src/lib.rs
+++ b/crates/grafana-plugin-sdk/src/lib.rs
@@ -47,7 +47,13 @@ pub use serde_json;
 #[cfg(feature = "reqwest")]
 extern crate reqwest_lib as reqwest;
 
-#[allow(missing_docs, clippy::all, clippy::nursery, clippy::pedantic)]
+#[allow(
+    missing_docs,
+    clippy::all,
+    clippy::nursery,
+    clippy::pedantic,
+    rustdoc::all
+)]
 pub mod pluginv2 {
     //! The low-level structs generated from protocol definitions.
     include!("pluginv2/pluginv2.rs");


### PR DESCRIPTION
- fix some outdated references to `ConfiguredPlugin`
- correctly feature flag `ArrayRefIntoField`
- use `RUSTDOCFLAGS` instead of `RUSTFLAGS` in docs CI
- allow rustdoc warnings on `pluginv2` generated code
- run `cargo doc` on PRs in CI
