### PR TITLE
chore: switch from arrow2 to arrow

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   This has also added a new field, `api_version`, to the `AppInstanceSettings` and
   `DataSourceInstanceSettings` structs.
 - The `ArrayRefIntoField` trait is now correctly hidden behind the `arrow` feature flag.
+- Switch from `arrow2` to `arrow`.
+  The `arrow2` crate has been deprecated and is no longer maintained. The SDK now uses the
+  `arrow` crate instead, which is maintained by the Arrow project.
+  This is a breaking change because the `Field::values()` method now returns an
+  `Arc<dyn arrow::array::Array>` instead of the `arrow2` equivalent, and the
+  APIs for working with arrow arrays differs between the two crates.
+  Users who are just using the simple `Field::set_values` method or the various
+  `IntoField` / `IntoOptField` traits should not be affected.
 
 ## [0.5.0] - 2024-09-17
 

--- a/crates/grafana-plugin-sdk/Cargo.toml
+++ b/crates/grafana-plugin-sdk/Cargo.toml
@@ -9,9 +9,7 @@ repository = "https://github.com/grafana/grafana-plugin-sdk-rust"
 description = "SDK for building Grafana backend plugins."
 
 [dependencies]
-arrow-array = { version = ">=40", optional = true } # synced with arrow2
-arrow-schema = { version = ">=40", optional = true } # synced with arrow2
-arrow2 = { version = "0.18.0", features = ["io_ipc"] }
+arrow = { version = "53.0.0", default-features = false, features = ["ipc"] }
 cfg-if = "1.0.0"
 chrono = "0.4.26"
 futures-core = "0.3.28"
@@ -63,7 +61,6 @@ all-features = true
 rustdoc-args = ["--cfg", "docsrs"]
 
 [features]
-arrow = ["dep:arrow-array", "dep:arrow-schema", "arrow2/arrow"]
 reqwest = ["reqwest_lib"]
 # Since prost 0.11 we no longer use prost-build at build time to generate code,
 # because it requires protoc. The generated code is instead checked in to source

--- a/crates/grafana-plugin-sdk/src/data/error.rs
+++ b/crates/grafana-plugin-sdk/src/data/error.rs
@@ -1,5 +1,5 @@
 //! Error types returned by the SDK.
-use arrow2::datatypes::DataType;
+use arrow::datatypes::DataType;
 use itertools::Itertools;
 use thiserror::Error;
 

--- a/crates/grafana-plugin-sdk/src/data/frame/mod.rs
+++ b/crates/grafana-plugin-sdk/src/data/frame/mod.rs
@@ -180,7 +180,7 @@ impl Frame {
     /// # Example
     ///
     /// ```rust
-    /// use arrow2::array::{PrimitiveArray, Utf8Array};
+    /// use arrow::{array::{PrimitiveArray, StringArray}, datatypes::UInt32Type};
     /// use grafana_plugin_sdk::prelude::*;
     ///
     /// // Create an initial `Frame`.
@@ -199,18 +199,18 @@ impl Frame {
     ///         .fields()[0]
     ///         .values()
     ///         .as_any()
-    ///         .downcast_ref::<PrimitiveArray<u32>>()
+    ///         .downcast_ref::<PrimitiveArray<UInt32Type>>()
     ///         .unwrap()
     ///         .iter()
-    ///         .collect::<Vec<_>>(),
-    ///     vec![Some(&4), Some(&5), Some(&6)],
+    ///         .collect::<Vec<Option<u32>>>(),
+    ///     vec![Some(4), Some(5), Some(6)],
     /// );
     /// assert_eq!(
     ///     frame
     ///         .fields()[1]
     ///         .values()
     ///         .as_any()
-    ///         .downcast_ref::<Utf8Array<i32>>()
+    ///         .downcast_ref::<StringArray>()
     ///         .unwrap()
     ///         .iter()
     ///         .collect::<Vec<_>>(),
@@ -236,7 +236,6 @@ impl Frame {
     /// # Example
     ///
     /// ```rust
-    /// use arrow2::array::{PrimitiveArray, Utf8Array};
     /// use grafana_plugin_sdk::prelude::*;
     ///
     /// assert!(

--- a/crates/grafana-plugin-sdk/src/lib.rs
+++ b/crates/grafana-plugin-sdk/src/lib.rs
@@ -34,12 +34,12 @@ The following feature flags enable additional functionality for this crate:
 #![cfg_attr(docsrs, feature(doc_notable_trait))]
 #![deny(missing_docs)]
 
-/// Re-export of the arrow2 crate depended on by this crate.
+/// Re-export of the arrow crate depended on by this crate.
 ///
-/// We recommend that you use this re-export rather than depending on arrow2
+/// We recommend that you use this re-export rather than depending on arrow
 /// directly to ensure compatibility; otherwise, rustc/cargo may emit mysterious
 /// error messages.
-pub use arrow2;
+pub use arrow;
 
 #[doc(hidden)]
 pub use serde_json;


### PR DESCRIPTION
arrow2 is now unmaintained; the community has decided to focus
on the arrow crate instead, which has changed a lot since the
initial decision to split off arrow2. This PR removes the dependency
on arrow2 and uses arrow, instead.

Needs some real-world testing before merging.
