### PR TITLE
ci: publish GH pages to this repo

### DIFF
--- a/.github/workflows/rustdoc.yml
+++ b/.github/workflows/rustdoc.yml
@@ -30,10 +30,9 @@ jobs:
       run: cargo doc --no-deps --features reqwest
 
     - name: Deploy Docs
-      uses: peaceiris/actions-gh-pages@v3.7.3
+      uses: peaceiris/actions-gh-pages@v4.0.0
       with:
-        personal_token: ${{ secrets.PERSONAL_TOKEN }}
+        personal_token: ${{ secrets.GITHUB_TOKEN }}
         publish_branch: gh-pages
         publish_dir: ./target/doc
         force_orphan: true
-        external_repository: sd2k/sd2k.github.io


### PR DESCRIPTION
Publish GH pages docs to this repo, not sd2k.github.io.